### PR TITLE
feat: GitHub Actions to build Erlang/Elixir for Windows

### DIFF
--- a/.github/workflows/build_docker_images.yaml
+++ b/.github/workflows/build_docker_images.yaml
@@ -3,7 +3,7 @@ name: Build Erlang/Elixir images
 on:
   workflow_dispatch:
   push:
-    branches: [initial]
+    branches: [windows-docker]
 
 jobs:
   build2019:
@@ -19,9 +19,13 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+      - name: Force build if workflow_dispatch or re-run
+        id: force
+        if: github.event_name == 'workflow_dispatch' || github.run_attempt != '1'
+        run: echo "::set-output name=force::-Force"
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Build Erlang tag (if needed)
-        run: ./build_erlang_container.ps1 -ImageNameRoot paulswartz/windows- -WindowsVersion ${{ matrix.windows_version }} -ErlangVersion ${{ matrix.erlang_version }}
+        run: ./build_erlang_container.ps1 -ImageNameRoot paulswartz/windows- -WindowsVersion ${{ matrix.windows_version }} -ErlangVersion ${{ matrix.erlang_version }} ${{ steps.force.outputs.force }}
       - name: Build Elixir tag (if needed)
-        run: ./build_elixir_container.ps1 -ImageNameRoot paulswartz/windows- -WindowsVersion ${{ matrix.windows_version }} -ErlangVersion ${{ matrix.erlang_version }} -ElixirVersion ${{ matrix.elixir_version }}
+        run: ./build_elixir_container.ps1 -ImageNameRoot paulswartz/windows- -WindowsVersion ${{ matrix.windows_version }} -ErlangVersion ${{ matrix.erlang_version }} -ElixirVersion ${{ matrix.elixir_version }} ${{ steps.force.outputs.force }}

--- a/.github/workflows/build_docker_images.yaml
+++ b/.github/workflows/build_docker_images.yaml
@@ -9,7 +9,7 @@ jobs:
   build2019:
     strategy:
       matrix:
-        erlang_version: [24.3.4.2, 25.0.4]
+        erlang_version: [24.3.4.4, 25.0.4]
         elixir_version: [1.13.4]
         windows_version: [1809]
     runs-on: windows-2019

--- a/.github/workflows/build_docker_images.yaml
+++ b/.github/workflows/build_docker_images.yaml
@@ -1,0 +1,27 @@
+name: Build Erlang/Elixir images
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [initial]
+
+jobs:
+  build2019:
+    strategy:
+      matrix:
+        erlang_version: [24.3.4.2]
+        elixir_version: [1.13.4]
+        windows_version: [1809]
+    runs-on: windows-2019
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Build Erlang tag (if needed)
+        run: ./build_erlang_container.ps1 -ImageNameRoot paulswartz/windows- -WindowsVersion ${{ matrix.windows_version }} -ErlangVersion ${{ matrix.erlang_version }}
+      - name: Build Elixir tag (if needed)
+        run: ./build_elixir_container.ps1 -ImageNameRoot paulswartz/windows- -WindowsVersion ${{ matrix.windows_version }} -ErlangVersion ${{ matrix.erlang_version }} -ElixirVersion ${{ matrix.elixir_version }}

--- a/.github/workflows/build_docker_images.yaml
+++ b/.github/workflows/build_docker_images.yaml
@@ -3,7 +3,7 @@ name: Build Erlang/Elixir images
 on:
   workflow_dispatch:
   push:
-    branches: [windows-docker]
+    branches: [main]
 
 jobs:
   build2019:
@@ -26,6 +26,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Build Erlang tag (if needed)
-        run: ./build_erlang_container.ps1 -ImageNameRoot paulswartz/windows- -WindowsVersion ${{ matrix.windows_version }} -ErlangVersion ${{ matrix.erlang_version }} ${{ steps.force.outputs.force }}
+        run: ./build_erlang_container.ps1 -ImageNameRoot ${{ secrets.DOCKER_USERNAME }}/windows- -WindowsVersion ${{ matrix.windows_version }} -ErlangVersion ${{ matrix.erlang_version }} ${{ steps.force.outputs.force }}
       - name: Build Elixir tag (if needed)
-        run: ./build_elixir_container.ps1 -ImageNameRoot paulswartz/windows- -WindowsVersion ${{ matrix.windows_version }} -ErlangVersion ${{ matrix.erlang_version }} -ElixirVersion ${{ matrix.elixir_version }} ${{ steps.force.outputs.force }}
+        run: ./build_elixir_container.ps1 -ImageNameRoot ${{ secrets.DOCKER_USERNAME }}/windows- -WindowsVersion ${{ matrix.windows_version }} -ErlangVersion ${{ matrix.erlang_version }} -ElixirVersion ${{ matrix.elixir_version }} ${{ steps.force.outputs.force }}

--- a/.github/workflows/build_docker_images.yaml
+++ b/.github/workflows/build_docker_images.yaml
@@ -9,7 +9,7 @@ jobs:
   build2019:
     strategy:
       matrix:
-        erlang_version: [24.3.4.2]
+        erlang_version: [24.3.4.2, 25.0.4]
         elixir_version: [1.13.4]
         windows_version: [1809]
     runs-on: windows-2019

--- a/build_elixir_container.ps1
+++ b/build_elixir_container.ps1
@@ -1,0 +1,31 @@
+param(
+    [string]$ImageNameRoot="",
+
+    [Parameter(Mandatory)]
+    [string]$WindowsVersion,
+
+    [Parameter(Mandatory)]
+    [string]$ErlangVersion,
+
+    [Parameter(Mandatory)]
+    [string]$ElixirVersion
+
+)
+
+$erlimage="${ImageNameRoot}erlang"
+$erltag="${ErlangVersion}-windows-${WindowsVersion}"
+$elixirimage="${ImageNameRoot}elixir"
+$elixirtag="${ElixirVersion}-erlang-${erltag}"
+
+docker manifest inspect "${elixirimage}:${elixirtag}" | Out-Null
+if ($?) {
+    Write-Output "Skipping ${elixirimage}:${elixirtag}, already exists."
+} else {
+  docker build docker -f docker/Dockerfile.elixir `
+    --build-arg BUILD_IMAGE="mcr.microsoft.com/windows/servercore:${WindowsVersion}" `
+    --build-arg FROM_IMAGE="${erlimage}:${erltag}" `
+    --build-arg ELIXIR_VERSION=$ElixirVersion `
+    --tag "${elixirimage}:${elixirtag}"
+
+  docker push "${elixirimage}:${elixirtag}"
+}

--- a/build_elixir_container.ps1
+++ b/build_elixir_container.ps1
@@ -8,7 +8,9 @@ param(
     [string]$ErlangVersion,
 
     [Parameter(Mandatory)]
-    [string]$ElixirVersion
+    [string]$ElixirVersion,
+
+    [switch]$Force=$false
 
 )
 
@@ -18,7 +20,7 @@ $elixirimage="${ImageNameRoot}elixir"
 $elixirtag="${ElixirVersion}-erlang-${erltag}"
 
 docker manifest inspect "${elixirimage}:${elixirtag}" | Out-Null
-if ($?) {
+if (-not $Force -and $?) {
     Write-Output "Skipping ${elixirimage}:${elixirtag}, already exists."
 } else {
   docker build docker -f docker/Dockerfile.elixir `

--- a/build_erlang_container.ps1
+++ b/build_erlang_container.ps1
@@ -5,13 +5,15 @@ param(
     [string]$WindowsVersion,
 
     [Parameter(Mandatory)]
-    [string]$ErlangVersion
+    [string]$ErlangVersion,
+
+    [switch]$Force=$false
 )
 $erlimage="${ImageNameRoot}erlang"
 $erltag="${ErlangVersion}-windows-${WindowsVersion}"
 
 docker manifest inspect "${erlimage}:${erltag}" | Out-Null
-if ($?) {
+if (-not $Force -and $?) {
     Write-Output "Skipping ${erlimage}:${erltag}, already exists."
 } else {
   docker build docker -f docker/Dockerfile.erlang `

--- a/build_erlang_container.ps1
+++ b/build_erlang_container.ps1
@@ -1,0 +1,24 @@
+param(
+    [string]$ImageNameRoot="",
+
+    [Parameter(Mandatory)]
+    [string]$WindowsVersion,
+
+    [Parameter(Mandatory)]
+    [string]$ErlangVersion
+)
+$erlimage="${ImageNameRoot}erlang"
+$erltag="${ErlangVersion}-windows-${WindowsVersion}"
+
+docker manifest inspect "${erlimage}:${erltag}" | Out-Null
+if ($?) {
+    Write-Output "Skipping ${erlimage}:${erltag}, already exists."
+} else {
+  docker build docker -f docker/Dockerfile.erlang `
+    --build-arg BUILD_IMAGE="mcr.microsoft.com/windows/servercore:${WindowsVersion}" `
+    --build-arg FROM_IMAGE="mcr.microsoft.com/windows/servercore:${WindowsVersion}" `
+    --build-arg OTP_VERSION=$ErlangVersion `
+    --tag "${erlimage}:${erltag}"
+
+  docker push "${erlimage}:${erltag}"
+}

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile.*

--- a/docker/Dockerfile.elixir
+++ b/docker/Dockerfile.elixir
@@ -1,0 +1,25 @@
+# Based on:
+# - https://github.com/StefanScherer/dockerfiles-windows/blob/main/chocolatey/Dockerfile
+# - https://github.com/avid-technology/docker-erlang-windows
+
+ARG BUILD_IMAGE
+ARG FROM_IMAGE
+
+FROM $BUILD_IMAGE as build
+ARG ELIXIR_VERSION
+
+# log which version of Windows we're using
+RUN ver
+
+ADD https://github.com/elixir-lang/elixir/releases/download/v${ELIXIR_VERSION}/Precompiled.zip ./elixir.zip
+SHELL ["powershell", "-Command"]
+RUN Expand-Archive -Path elixir.zip -DestinationPath "C:\Elixir"
+
+FROM $FROM_IMAGE
+
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;C:\Elixir\bin"
+
+USER ContainerUser
+
+COPY --from=build C:\\Elixir C:\\Elixir

--- a/docker/Dockerfile.elixir
+++ b/docker/Dockerfile.elixir
@@ -20,6 +20,9 @@ FROM $FROM_IMAGE
 USER ContainerAdministrator
 RUN setx /M PATH "%PATH%;C:\Elixir\bin"
 
-USER ContainerUser
-
 COPY --from=build C:\\Elixir C:\\Elixir
+
+USER ContainerUser
+RUN mix local.hex --force \
+    && mix local.rebar --force
+

--- a/docker/Dockerfile.elixir
+++ b/docker/Dockerfile.elixir
@@ -2,11 +2,11 @@
 # - https://github.com/StefanScherer/dockerfiles-windows/blob/main/chocolatey/Dockerfile
 # - https://github.com/avid-technology/docker-erlang-windows
 
-ARG BUILD_IMAGE
-ARG FROM_IMAGE
+ARG BUILD_IMAGE=paulswartz/windows-erlang:24.3.4.2-windows-1809
+ARG FROM_IMAGE=$BUILD_IMAGE
 
 FROM $BUILD_IMAGE as build
-ARG ELIXIR_VERSION
+ARG ELIXIR_VERSION=1.13.4
 
 # log which version of Windows we're using
 RUN ver

--- a/docker/Dockerfile.erlang
+++ b/docker/Dockerfile.erlang
@@ -2,17 +2,17 @@
 # - https://github.com/StefanScherer/dockerfiles-windows/blob/main/chocolatey/Dockerfile
 # - https://github.com/avid-technology/docker-erlang-windows
 
-ARG BUILD_IMAGE
-ARG FROM_IMAGE
+ARG BUILD_IMAGE=mcr.microsoft.com/windows/servercore:1809
+ARG FROM_IMAGE=$BUILD_IMAGE
 
 FROM $BUILD_IMAGE as build
 
 # log which version of Windows we're using
 RUN ver
 
-ARG OTP_VERSION
-ADD https://github.com/erlang/otp/releases/download/OTP-${OTP_VERSION}/otp_win64_${OTP_VERSION}.exe ./otp-installer.exe
-RUN otp-installer.exe /S /w /v"/qn /D=C:\Erlang"
+ARG OTP_VERSION=24.3.4.2
+RUN curl -fSLo otp-installer.exe "https://github.com/erlang/otp/releases/download/OTP-%OTP_VERSION%/otp_win64_%OTP_VERSION%.exe" \
+    && start /w otp-installer.exe /S /w /v"/qn /D=C:\Erlang"
 
 FROM $FROM_IMAGE
 

--- a/docker/Dockerfile.erlang
+++ b/docker/Dockerfile.erlang
@@ -17,7 +17,10 @@ RUN otp-installer.exe /S /w /v"/qn /D=C:\Erlang"
 FROM $FROM_IMAGE
 
 USER ContainerAdministrator
-RUN setx /M PATH "%PATH%;C:\Erlang\bin"
+RUN curl -fSLo vc_redist.x64.exe https://aka.ms/vs/17/release/vc_redist.x64.exe \
+    && start /w vc_redist.x64.exe /install /quiet /norestart \
+    && del vc_redist.x64.exe \
+    && setx /M PATH "%PATH%;C:\Erlang\bin"
 
 USER ContainerUser
 

--- a/docker/Dockerfile.erlang
+++ b/docker/Dockerfile.erlang
@@ -19,9 +19,15 @@ FROM $FROM_IMAGE
 USER ContainerAdministrator
 RUN curl -fSLo vc_redist.x64.exe https://aka.ms/vs/17/release/vc_redist.x64.exe \
     && start /w vc_redist.x64.exe /install /quiet /norestart \
-    && del vc_redist.x64.exe \
-    && setx /M PATH "%PATH%;C:\Erlang\bin"
+    && del vc_redist.x64.exe
 
-USER ContainerUser
+ARG GIT_VERSION=2.37.1
+RUN curl -fSLo Git-Install.exe "https://github.com/git-for-windows/git/releases/download/v%GIT_VERSION%.windows.1/Git-%GIT_VERSION%-64-bit.exe" \
+    && start /w Git-Install.exe /VERYSILENT /NORESTART /NOCANCEL \
+    && del Git-Install.exe
+
+RUN setx /M PATH "%PATH%;C:\Erlang\bin"
 
 COPY --from=build C:\\Erlang C:\\Erlang
+
+USER ContainerUser

--- a/docker/Dockerfile.erlang
+++ b/docker/Dockerfile.erlang
@@ -1,0 +1,24 @@
+# Based on:
+# - https://github.com/StefanScherer/dockerfiles-windows/blob/main/chocolatey/Dockerfile
+# - https://github.com/avid-technology/docker-erlang-windows
+
+ARG BUILD_IMAGE
+ARG FROM_IMAGE
+
+FROM $BUILD_IMAGE as build
+
+# log which version of Windows we're using
+RUN ver
+
+ARG OTP_VERSION
+ADD https://github.com/erlang/otp/releases/download/OTP-${OTP_VERSION}/otp_win64_${OTP_VERSION}.exe ./otp-installer.exe
+RUN otp-installer.exe /S /w /v"/qn /D=C:\Erlang"
+
+FROM $FROM_IMAGE
+
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;C:\Erlang\bin"
+
+USER ContainerUser
+
+COPY --from=build C:\\Erlang C:\\Erlang


### PR DESCRIPTION
Unfortunately, Hex.pm does not create builds for Windows. And without Docker builds for Windows, each time one of our Windows applications would want to build an Erlang/Elixir application, they would need to do it themselves.

This action creates a set of builds for a given set of Erlang/Elixir versions. From there, Docker containers for individual applications can use them as they would for Linux containers: using them as the base for building a release.

Currently these are going into my personal DockerHub (https://hub.docker.com/repository/docker/paulswartz/windows-erlang/tags and https://hub.docker.com/repository/docker/paulswartz/windows-elixir/tags) but we should update that to go into the `mbta` account as a part of merging this.