### PR TITLE
include more versions of Erlang/Elixir in the build matrix

### DIFF
--- a/.github/workflows/build_docker_images.yaml
+++ b/.github/workflows/build_docker_images.yaml
@@ -9,10 +9,60 @@ jobs:
   build2019:
     continue-on-error: true
     strategy:
+      # Compatibility matrix:
+      # https://hexdocs.pm/elixir/1.14.0/compatibility-and-deprecations.html
       matrix:
-        erlang_version: [24.3.4.4, 24.3.4.5, 25.0.4]
-        elixir_version: [1.13.4, 1.14.0]
-        windows_version: [1809]
+        include:
+          # Elixir 1.14
+          - elixir_version: 1.14.0
+            erlang_version: 25.0.4
+            windows_version: 1809
+          - elixir_version: 1.14.0
+            erlang_version: 24.3.4.5
+            windows_version: 1809
+          - elixir_version: 1.14.0
+            erlang_version: 23.3.4.9
+            windows_version: 1809
+          # Elixir 1.13.4
+          - elixir_version: 1.13.4
+            erlang_version: 25.0.4
+            windows_version: 1809
+          - elixir_version: 1.13.4
+            erlang_version: 24.3.4.5
+            windows_version: 1809
+          - elixir_version: 1.13.4
+            erlang_version: 23.3.4.9
+            windows_version: 1809
+          - elixir_version: 1.13.4
+            erlang_version: 22.3
+            windows_version: 1809
+          # Erlang 1.12.3
+          - elixir_version: 1.12.3
+            erlang_version: 24.3.4.5
+            windows_version: 1809
+          - elixir_version: 1.12.3
+            erlang_version: 23.3.4.9
+            windows_version: 1809
+          - elixir_version: 1.12.3
+            erlang_version: 22.3
+            windows_version: 1809
+          # Erlang 1.11.3
+          - elixir_version: 1.12.3
+            erlang_version: 24.3.4.5
+            windows_version: 1809
+          - elixir_version: 1.11.3
+            erlang_version: 23.3.4.9
+            windows_version: 1809
+          - elixir_version: 1.11.3
+            erlang_version: 22.3
+            windows_version: 1809
+          # Erlang 1.10.4
+          - elixir_version: 1.10.4
+            erlang_version: 23.3.4.9
+            windows_version: 1809
+          - elixir_version: 1.10.4
+            erlang_version: 22.3
+            windows_version: 1809
     runs-on: windows-2019
     steps:
       - name: Login to Docker Hub

--- a/docker/Dockerfile.elixir
+++ b/docker/Dockerfile.elixir
@@ -7,7 +7,7 @@ ARG FROM_IMAGE=$BUILD_IMAGE
 
 FROM $BUILD_IMAGE as build
 ARG ELIXIR_VERSION=1.13.4
-ARG ELIXIR_ZIP=Precompiled.zip
+ARG ELIXIR_ZIP=Precompiled
 
 # log which version of Windows we're using
 RUN ver

--- a/docker/Dockerfile.erlang
+++ b/docker/Dockerfile.erlang
@@ -17,10 +17,6 @@ RUN curl -fSLo otp-installer.exe "https://github.com/erlang/otp/releases/downloa
 FROM $FROM_IMAGE
 
 USER ContainerAdministrator
-RUN curl -fSLo vc_redist.x64.exe https://aka.ms/vs/17/release/vc_redist.x64.exe \
-    && start /w vc_redist.x64.exe /install /quiet /norestart \
-    && del vc_redist.x64.exe
-
 ARG GIT_VERSION=2.37.1
 RUN curl -fSLo Git-Install.exe "https://github.com/git-for-windows/git/releases/download/v%GIT_VERSION%.windows.1/Git-%GIT_VERSION%-64-bit.exe" \
     && start /w Git-Install.exe /VERYSILENT /NORESTART /NOCANCEL \
@@ -29,5 +25,7 @@ RUN curl -fSLo Git-Install.exe "https://github.com/git-for-windows/git/releases/
 RUN setx /M PATH "%PATH%;C:\Erlang\bin"
 
 COPY --from=build C:\\Erlang C:\\Erlang
+
+RUN C:\Erlang\vcredist_x64.exe /install /quiet /norestart
 
 USER ContainerUser


### PR DESCRIPTION
This will allow us to build containers with the existing versions of Erlang/Elixir, rather than needing to update before we migrate to a container.