### PR TITLE
include new Erlang versions, build them before the Elixir containers

### DIFF
--- a/.github/workflows/build_docker_images.yaml
+++ b/.github/workflows/build_docker_images.yaml
@@ -6,14 +6,46 @@ on:
     branches: [main]
 
 jobs:
-  build2019:
+  erlang2019:
+    name: Erlang images
     continue-on-error: true
+    strategy:
+      # Supported Erlang versions: search for `otp_win64` in
+      # https://erlang.org/download/
+      matrix:
+        include:
+          - erlang_version: 25.1
+            windows_version: 1809
+          - erlang_version: 25.0.4
+            windows_version: 1809
+          - erlang_version: 24.3.4.5
+            windows_version: 1809
+          - erlang_version: 23.3.4.17
+            windows_version: 1809
+          - erlang_version: 22.3
+            windows_version: 1809
+    runs-on: windows-2019
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+      - name: Force build if workflow_dispatch or re-run
+        id: force
+        if: github.event_name == 'workflow_dispatch' || github.run_attempt != '1'
+        run: echo "::set-output name=force::-Force"
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Build Erlang tag (if needed)
+        run: ./build_erlang_container.ps1 -ImageNameRoot ${{ secrets.DOCKER_USERNAME }}/windows- -WindowsVersion ${{ matrix.windows_version }} -ErlangVersion ${{ matrix.erlang_version }} ${{ steps.force.outputs.force }}
+  elixir2019:
+    name: Elixir images
+    continue-on-error: true
+    needs: erlang2019
     strategy:
       # Elixir compatibility matrix:
       # https://hexdocs.pm/elixir/1.14.0/compatibility-and-deprecations.html
-      #
-      # Supported Erlang versions: search for `otp_win64` in
-      # https://erlang.org/download/
       matrix:
         include:
           # Elixir 1.14
@@ -85,7 +117,5 @@ jobs:
         run: echo "::set-output name=force::-Force"
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Build Erlang tag (if needed)
-        run: ./build_erlang_container.ps1 -ImageNameRoot ${{ secrets.DOCKER_USERNAME }}/windows- -WindowsVersion ${{ matrix.windows_version }} -ErlangVersion ${{ matrix.erlang_version }} ${{ steps.force.outputs.force }}
       - name: Build Elixir tag (if needed)
         run: ./build_elixir_container.ps1 -ImageNameRoot ${{ secrets.DOCKER_USERNAME }}/windows- -WindowsVersion ${{ matrix.windows_version }} -ErlangVersion ${{ matrix.erlang_version }} -ElixirVersion ${{ matrix.elixir_version }} ${{ steps.force.outputs.force }}

--- a/.github/workflows/build_docker_images.yaml
+++ b/.github/workflows/build_docker_images.yaml
@@ -18,23 +18,29 @@ jobs:
         include:
           # Elixir 1.14
           - elixir_version: 1.14.0
+            erlang_version: 25.1
+            windows_version: 1809
+          - elixir_version: 1.14.0
             erlang_version: 25.0.4
             windows_version: 1809
           - elixir_version: 1.14.0
             erlang_version: 24.3.4.5
             windows_version: 1809
           - elixir_version: 1.14.0
-            erlang_version: 23.3.4.9
+            erlang_version: 23.3.4.17
             windows_version: 1809
           # Elixir 1.13.4
           - elixir_version: 1.13.4
+            erlang_version: 25.1
+            windows_version: 1809
+          - elixir_version: 1.13.4
             erlang_version: 25.0.4
             windows_version: 1809
           - elixir_version: 1.13.4
             erlang_version: 24.3.4.5
             windows_version: 1809
           - elixir_version: 1.13.4
-            erlang_version: 23.3.4.9
+            erlang_version: 23.3.4.17
             windows_version: 1809
           - elixir_version: 1.13.4
             erlang_version: 22.3
@@ -44,7 +50,7 @@ jobs:
             erlang_version: 24.3.4.5
             windows_version: 1809
           - elixir_version: 1.12.3
-            erlang_version: 23.3.4.9
+            erlang_version: 23.3.4.17
             windows_version: 1809
           - elixir_version: 1.12.3
             erlang_version: 22.3
@@ -54,14 +60,14 @@ jobs:
             erlang_version: 24.3.4.5
             windows_version: 1809
           - elixir_version: 1.11.3
-            erlang_version: 23.3.4.9
+            erlang_version: 23.3.4.17
             windows_version: 1809
           - elixir_version: 1.11.3
             erlang_version: 22.3
             windows_version: 1809
           # Erlang 1.10.4
           - elixir_version: 1.10.4
-            erlang_version: 23.3.4.9
+            erlang_version: 23.3.4.17
             windows_version: 1809
           - elixir_version: 1.10.4
             erlang_version: 22.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: Unit Tests
 
 on:
   push:
+  pull_request:
 
 jobs:
   update:

--- a/docker/Dockerfile.erlang
+++ b/docker/Dockerfile.erlang
@@ -17,7 +17,7 @@ RUN curl -fSLo otp-installer.exe "https://github.com/erlang/otp/releases/downloa
 FROM $FROM_IMAGE
 
 USER ContainerAdministrator
-ARG GIT_VERSION=2.37.1
+ARG GIT_VERSION=2.37.3
 RUN curl -fSLo Git-Install.exe "https://github.com/git-for-windows/git/releases/download/v%GIT_VERSION%.windows.1/Git-%GIT_VERSION%-64-bit.exe" \
     && start /w Git-Install.exe /VERYSILENT /NORESTART /NOCANCEL \
     && del Git-Install.exe


### PR DESCRIPTION
Otherwise, multiple jobs will try to build the same Erlang container.