### PR TITLE
fix: include fake port when binding

### DIFF
--- a/scripts/Helpers.Tests.ps1
+++ b/scripts/Helpers.Tests.ps1
@@ -38,7 +38,8 @@ Describe "ContainerStack" {
             -SplunkIndex "idx" `
             -TaskPort "4000" `
         | ConvertFrom-Yaml
-        $output.services.container.ports | Should -HaveCount 1
+        # count includes fake port
+        $output.services.container.ports | Should -HaveCount 2
         $output.services.container.ports[0] | Should -Be "4000:4000"
     }
 
@@ -51,7 +52,8 @@ Describe "ContainerStack" {
             -SplunkIndex "idx" `
             -TaskPort "4000 5000" `
         | ConvertFrom-Yaml
-        $output.services.container.ports | Should -HaveCount 2
+        # count includes fake port
+        $output.services.container.ports | Should -HaveCount 3
         $output.services.container.ports[0] | Should -Be "4000:4000"
         $output.services.container.ports[1] | Should -Be "5000:5000"
     }

--- a/scripts/Helpers.ps1
+++ b/scripts/Helpers.ps1
@@ -70,10 +70,11 @@ $($environmentRows -Join "`n")
         ""
     } else {
         $portRows = $TaskPort.split(" ") `
-          | ForEach-Object { "      - ${_}:${_}" }
+          | ForEach-Object { "      - '${_}:${_}'" }
         @"
     ports:
 $($portRows -Join "`n")
+      - '60000'
 "@
     }
 


### PR DESCRIPTION
For an unknown reason, Docker Swarm on Windows appears to lose the binding for the last port during some restarts. This attempts to address the issue by providing a fake port to bind, which we don't care if it fails.