### PR TITLE
feat: always run SSH logins through the Google authenticator

### DIFF
--- a/linux/roles/onprem/files/google-authenticator.sh
+++ b/linux/roles/onprem/files/google-authenticator.sh
@@ -8,3 +8,9 @@ fi
 if [ ! -f $HOME/.google_authenticator ]; then
     exit 1
 fi
+
+if [ -z "$SSH_ORIGINAL_COMMAND" ]; then
+    exec "$SHELL"
+else
+    exec "$SHELL" -c "$SSH_ORIGINAL_COMMAND"
+fi

--- a/linux/roles/onprem/files/google-authenticator.sh
+++ b/linux/roles/onprem/files/google-authenticator.sh
@@ -1,16 +1,20 @@
 #!/usr/bin/env sh
-# only require this for members of the `users` group
-id -nG "$USER" | grep -qw "users" || return
-trap "exit 1" SIGINT SIGQUIT
-if [ ! -f $HOME/.google_authenticator ]; then
+
+# trap exits, rather than allowing a user to ^C out of the script
+trap "exit 1" INT QUIT
+
+google_authenticator_path="${HOME:?}"/.google_authenticator
+
+if [ ! -f "$google_authenticator_path" ]; then
     google-authenticator -ftDW -r 3 -R 30
-fi
-if [ ! -f $HOME/.google_authenticator ]; then
-    exit 1
+
+    # Ensure that the Google Authenticator file was created
+    test -f "$google_authenticator_path" || exit 1
 fi
 
+# Either run the shell, or the original command
 if [ -z "$SSH_ORIGINAL_COMMAND" ]; then
-    exec "$SHELL"
+    exec "$SHELL" -i
 else
     exec "$SHELL" -c "$SSH_ORIGINAL_COMMAND"
 fi

--- a/linux/roles/onprem/tasks/google-authenticator.yml
+++ b/linux/roles/onprem/tasks/google-authenticator.yml
@@ -6,7 +6,7 @@
 - name: Require Google Authenticator configuration on login
   copy:
     src: files/google-authenticator.sh
-    dest: /etc/profile.d/google-authenticator.sh
+    dest: /usr/local/sbin/enforce-google-authenticator
     owner: root
     group: root
     mode: '0755'
@@ -55,6 +55,7 @@
     group: root
     mode: '0644'
     content: |
+     ForceCommand /usr/local/sbin/enforce-google-authenticator
      AuthenticationMethods publickey,keyboard-interactive
      ChallengeResponseAuthentication yes
   notify: ssh


### PR DESCRIPTION
Previously, you could run `ssh -t host bash` and get a shell, but
without needing to provide an MFA token.