### PR TITLE
feat: register SSM/ECS tags for instances

### DIFF
--- a/linux/inventory.yml
+++ b/linux/inventory.yml
@@ -6,10 +6,16 @@ local:
   hosts:
     vagrant:
     qemu:
+      ecs_anywhere_attributes:
+        com.mbta.ctd.emulator: qemu
+        com.mbta.ctd.empty-attribute:
     local[01:99]:
 staging:
   hosts:
-    HSCTDLNXSTG[01:99]:
+    HSCTDLNXSTG01:
+      ecs_anywhere_attributes:
+        com.mbta.ctd.primary-instance:
+    HSCTDLNXSTG[02:99]:
     PPCTDLNXSTG[01:99]:
 prod:
   hosts:

--- a/linux/main.yml
+++ b/linux/main.yml
@@ -12,10 +12,14 @@
 - name: Local development
   hosts: local
   roles:
-    - ecs_anywhere
-    - splunk
-    - crowdstrike
-    - tenable
+    - role: ecs_anywhere
+      tags: [ecs_anywhere]
+    - role: splunk
+      tags: [splunk]
+    - role: crowdstrike
+      tags: [crowdstrike]
+    - role: tenable
+      tags: [tenable]
 - name: Staging environment
   hosts: staging
   vars:

--- a/linux/roles/ecs_anywhere/defaults/main.yml
+++ b/linux/roles/ecs_anywhere/defaults/main.yml
@@ -7,6 +7,7 @@ ecs_anywhere_cluster: linux-test
 # these are encrypted, stored in group_vars/<group>/vault.yml
 ecs_anywhere_activation_id: "{{ vault_ecs_anywhere_activation_id }}"
 ecs_anywhere_activation_code: "{{ vault_ecs_anywhere_activation_code }}"
+ecs_anywhere_attributes: {}
 
 s3_config_region: us-east-1
 # these are encrypted, stored in group_vars/all/s3_config.yml

--- a/linux/roles/ecs_anywhere/tasks/main.yml
+++ b/linux/roles/ecs_anywhere/tasks/main.yml
@@ -134,3 +134,25 @@
 - name: Boto3 package is installed
   ansible.builtin.pip:
     name: boto3
+- name: Fetch CLI install script
+  ansible.builtin.get_url:
+    dest: /root/awscliv2.zip
+    owner: root
+    group: root
+    mode: '0600'
+    url: "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
+  register: ecs_anywhere_cli_zip
+- name: Unzip is installed
+  ansible.builtin.apt:
+    name: unzip
+    state: present
+- name: Expand AWSCLI
+  when: ecs_anywhere_cli_zip.changed # noqa: no-handler
+  ansible.builtin.unarchive:
+    src: /root/awscliv2.zip
+    dest: /root
+- name: Install AWSCLI
+  when: ecs_anywhere_cli_zip.changed # noqa: no-handler
+  changed_when: true
+  ansible.builtin.command:
+    /root/aws/install --bin-dir /usr/local/bin --update

--- a/linux/roles/ecs_anywhere/tasks/main.yml
+++ b/linux/roles/ecs_anywhere/tasks/main.yml
@@ -164,7 +164,7 @@
     group: root
     mode: '0755'
 - name: Create ECS agent facts
-  register: ecs_anywhere_fact
+  register: ecs_anywhere_ecs_fact
   ansible.builtin.copy:
     content: |
       #!/bin/sh
@@ -173,9 +173,27 @@
     owner: root
     group: root
     mode: '0755'
+- name: Create SSM facts
+  register: ecs_anywhere_ssm_fact
+  ansible.builtin.copy:
+    content: |
+      #!/bin/sh
+      cat /var/lib/amazon/ssm/registration
+    dest: /etc/ansible/facts.d/ssm-agent.fact
+    owner: root
+    group: root
+    mode: '0755'
 - name: Rerun Ansible setup
   ansible.builtin.setup: ~
-  when: ecs_anywhere_fact.changed # noqa: no-handler
+  when: ecs_anywhere_ecs_fact.changed or ecs_anywhere_ssm_fact.changed # noqa: no-handler
+- name: Write hostname as Name tag
+  ansible.builtin.command: >-
+    aws ssm add-tags-to-resource
+    --region {{ ecs_anywhere_region }}
+    --resource-type ManagedInstance
+    --resource-id {{ ansible_local["ssm-agent"]["ManagedInstanceID"] }}
+    --tags Key=Name,Value={{ inventory_hostname }}
+  changed_when: false
 - name: Write container attributes
   loop: "{{ ecs_anywhere_attributes | dict2items }}"
   when: item.value

--- a/linux/roles/ecs_anywhere/tasks/main.yml
+++ b/linux/roles/ecs_anywhere/tasks/main.yml
@@ -156,3 +156,31 @@
   changed_when: true
   ansible.builtin.command:
     /root/aws/install --bin-dir /usr/local/bin --update
+- name: Create /etc/ansible/facts.d
+  ansible.builtin.file:
+    state: directory
+    path: /etc/ansible/facts.d
+    owner: root
+    group: root
+    mode: '0755'
+- name: Create ECS agent facts
+  register: ecs_anywhere_fact
+  ansible.builtin.copy:
+    content: |
+      #!/bin/sh
+      curl -s http://localhost:51678/v1/metadata
+    dest: /etc/ansible/facts.d/ecs-agent.fact
+    owner: root
+    group: root
+    mode: '0755'
+- name: Rerun Ansible setup
+  ansible.builtin.setup: ~
+  when: ecs_anywhere_fact.changed
+- name: Try writing ECS Agent ARN
+  ansible.builtin.copy:
+    content: >
+      {{ ansible_local["ecs-agent"]["ContainerInstanceArn"] }}
+    dest: /root/container-instance-arn
+    owner: root
+    group: root
+    mode: '0644'

--- a/linux/roles/ecs_anywhere/tasks/main.yml
+++ b/linux/roles/ecs_anywhere/tasks/main.yml
@@ -175,12 +175,24 @@
     mode: '0755'
 - name: Rerun Ansible setup
   ansible.builtin.setup: ~
-  when: ecs_anywhere_fact.changed
-- name: Try writing ECS Agent ARN
-  ansible.builtin.copy:
-    content: >
-      {{ ansible_local["ecs-agent"]["ContainerInstanceArn"] }}
-    dest: /root/container-instance-arn
-    owner: root
-    group: root
-    mode: '0644'
+  when: ecs_anywhere_fact.changed # noqa: no-handler
+- name: Write container attributes
+  loop: "{{ ecs_anywhere_attributes | dict2items }}"
+  when: item.value
+  changed_when: false
+  ansible.builtin.command:
+    cmd: >-
+      aws ecs put-attributes
+      --cluster {{ ecs_anywhere_cluster }}
+      --region {{ ecs_anywhere_region }}
+      --attributes "name={{ item.key }},value={{ item.value }},targetId={{ ansible_local["ecs-agent"]["ContainerInstanceArn"] }}"
+- name: Write container attributes (empty)
+  loop: "{{ ecs_anywhere_attributes | dict2items }}"
+  when: not item.value
+  changed_when: false
+  ansible.builtin.command:
+    cmd: >-
+      aws ecs put-attributes
+      --cluster {{ ecs_anywhere_cluster }}
+      --region {{ ecs_anywhere_region }}
+      --attributes "name={{ item.key }},targetId={{ ansible_local["ecs-agent"]["ContainerInstanceArn"] }}"

--- a/linux/roles/onprem/tasks/ansible-pull.yml
+++ b/linux/roles/onprem/tasks/ansible-pull.yml
@@ -11,7 +11,7 @@
 - name: Ensure cron is present
   ansible.builtin.apt:
     name: cron
-- name: Run ansible-pull every 15m
+- name: Run ansible-pull periodically
   ansible.builtin.cron:
     name: ansible-pull
     user: root
@@ -25,4 +25,4 @@
       --extra-vars "github_repo={{ github_repo }} git_branch={{ git_branch }}"
       linux/main.yml
       | /usr/bin/logger -t ansible-pull --id="${PPID}" -S 4096
-    minute: "*/15"
+    minute: "59"


### PR DESCRIPTION
The SSM tag is useful because it shows the hostname in the SSM console.
The ECS tags are useful because we can limit tasks to particular instances (see mbta/devops#1004)