### PR TITLE
feat: log `needrestart` output to Splunk every day

### DIFF
--- a/linux/roles/onprem/tasks/ansible-pull.yml
+++ b/linux/roles/onprem/tasks/ansible-pull.yml
@@ -25,4 +25,4 @@
       --extra-vars "github_repo={{ github_repo }} git_branch={{ git_branch }}"
       linux/main.yml
       | /usr/bin/logger -t ansible-pull --id="${PPID}" -S 4096
-    minute: "59"
+    special_time: "hourly"

--- a/linux/roles/onprem/tasks/main.yml
+++ b/linux/roles/onprem/tasks/main.yml
@@ -7,3 +7,5 @@
   ansible.builtin.include_tasks: users.yml
 - name: Unattended-upgrades configuration
   ansible.builtin.include_tasks: unattended-upgrades.yml
+- name: Needs Restart configuration
+  ansible.builtin.include_tasks: needs-restart.yml

--- a/linux/roles/onprem/tasks/needs-restart.yml
+++ b/linux/roles/onprem/tasks/needs-restart.yml
@@ -13,3 +13,11 @@
       needrestart -b
       | /usr/bin/logger -t needrestart --id="${PPID}" -S 4096
     special_time: "daily"
+- name: Cat /var/run/reboot-required daily
+  ansible.builtin.cron:
+    name: reboot-required
+    user: root
+    job: >-
+      test -f /var/run/reboot-required && cat /var/run/reboot-required
+      | /usr/bin/logger -t reboot-required --id="${PPID}" -S 4096
+    special_time: "daily"

--- a/linux/roles/onprem/tasks/needs-restart.yml
+++ b/linux/roles/onprem/tasks/needs-restart.yml
@@ -1,0 +1,15 @@
+---
+- name: Ensure packages are present
+  ansible.builtin.apt:
+    name: "{{ item }}"
+  loop:
+    - cron
+    - needrestart
+- name: Run needrestart daily
+  ansible.builtin.cron:
+    name: needrestart
+    user: root
+    job: >-
+      needrestart -b
+      | /usr/bin/logger -t needrestart --id="${PPID}" -S 4096
+    special_time: "daily"


### PR DESCRIPTION
From here, we can create an alert which will notify us when the server (or relevant services) need to be restarted.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204918040375937