### PR TITLE
feat: update Linux arguments to go back to cgroups v1

### DIFF
--- a/linux/roles/ecs_anywhere/handlers/main.yml
+++ b/linux/roles/ecs_anywhere/handlers/main.yml
@@ -12,3 +12,14 @@
   ansible.builtin.service:
     name: ecs
     state: restarted
+- name: Update Grub
+  ansible.builtin.command: update-grub
+  changed_when: false
+- name: Reboot required
+  ansible.builtin.copy:
+    content: >-
+      *** Reboot required to update Grub ***
+    dest: /var/run/reboot-required
+    owner: root
+    group: root
+    mode: '0644'

--- a/linux/roles/ecs_anywhere/tasks/main.yml
+++ b/linux/roles/ecs_anywhere/tasks/main.yml
@@ -215,3 +215,11 @@
       --cluster {{ ecs_anywhere_cluster }}
       --region {{ ecs_anywhere_region }}
       --attributes "name={{ item.key }},targetId={{ ansible_local["ecs-agent"]["ContainerInstanceArn"] }}"
+- name: Configure Grub to use cgroups v1
+  ansible.builtin.lineinfile:
+    path: /etc/default/grub
+    regexp: "^GRUB_CMDLINE_LINUX="
+    line: 'GRUB_CMDLINE_LINUX="systemd.unified_cgroup_hierarchy=false"'
+  notify:
+    - Update Grub
+    - Reboot required


### PR DESCRIPTION
This is what's supported for ECS Anywhere.