### PR TITLE
more efficiency updates

### DIFF
--- a/linux/roles/ecs_anywhere/tasks/main.yml
+++ b/linux/roles/ecs_anywhere/tasks/main.yml
@@ -1,22 +1,22 @@
 ---
 - name: Ensure required packages are installed
   ansible.builtin.apt:
-    name: "{{ item }}"
+    name:
+      - ca-certificates
+      - curl
+      - gnupg
+      - python3-pip
+      - unzip
     state: present
-  loop:
-    - ca-certificates
-    - curl
-    - gnupg
 - name: Ensure old Docker packages are not installed
   ansible.builtin.apt:
-    name: "{{ item }}"
+    name:
+      - docker
+      - docker-engine
+      - docker.io
+      - containerd
+      - runc
     state: absent
-  loop:
-    - docker
-    - docker-engine
-    - docker.io
-    - containerd
-    - runc
 - name: Check if AWS GPG key is present
   register: ecs_anywhere_aws_gpg_key_check
   ansible.builtin.command: gpg --list-keys {{ ecs_anywhere_aws_gpg_key }} 2> /dev/null
@@ -54,6 +54,7 @@
       stable
   changed_when: false
 - name: Add Docker repo to apt
+  register: ecs_anywhere_add_docker_repo
   ansible.builtin.copy:
     content: "{{ ecs_anywhere_docker_list.stdout }}"
     dest: /etc/apt/sources.list.d/docker.list
@@ -62,15 +63,15 @@
     mode: '0644'
 - name: Ensure new Docker packages are installed
   ansible.builtin.apt:
-    name: "{{ item }}"
+    name:
+      - docker-ce
+      - docker-ce-cli
+      - containerd.io
+      - docker-buildx-plugin
+      - docker-compose-plugin
     state: present
-    update_cache: true
-  loop:
-    - docker-ce
-    - docker-ce-cli
-    - containerd.io
-    - docker-buildx-plugin
-    - docker-compose-plugin
+    update_cache: "{{ ecs_anywhere_add_docker_repo.changed }}"
+    cache_valid_time: 60
 - name: Apparmor profile for Docker
   ansible.builtin.copy:
     src: files/docker-default
@@ -128,10 +129,6 @@
   ansible.builtin.service:
     name: amazon-ssm-agent
     state: started
-- name: Pip is installed
-  ansible.builtin.apt:
-    name: python3-pip
-    state: present
 - name: Boto3 package is installed
   ansible.builtin.pip:
     name: boto3
@@ -143,10 +140,6 @@
     mode: '0600'
     url: "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
   register: ecs_anywhere_cli_zip
-- name: Unzip is installed
-  ansible.builtin.apt:
-    name: unzip
-    state: present
 - name: Expand AWSCLI
   when: ecs_anywhere_cli_zip.changed # noqa: no-handler
   ansible.builtin.unarchive:

--- a/linux/roles/metrics/tasks/main.yml
+++ b/linux/roles/metrics/tasks/main.yml
@@ -1,10 +1,9 @@
 - name: Ensure packages are installed
   ansible.builtin.apt:
-    name: "{{ item }}"
+    name:
+      - collectd
+      - net-tools
     state: present
-  loop:
-    - collectd
-    - net-tools
 - name: Configure collectd to send to Splunk
   ansible.builtin.template:
     src: templates/splunk.conf.j2

--- a/linux/roles/onprem/tasks/ansible-pull.yml
+++ b/linux/roles/onprem/tasks/ansible-pull.yml
@@ -16,13 +16,18 @@
     requirements_file: collections/requirements.yml
   when: onprem_ansible_requirements.changed # noqa: no-handler
 - name: Ensure Ansible PPA is present
+  register: onprem_ansible_ppa
   ansible.builtin.apt_repository:
     repo: "ppa:ansible/ansible"
     # matches what's generated from cloud-init/user-data
     filename: "ansible-ubuntu-ansible-jammy"
-- name: Ensure cron is present
+- name: Ensure packages are present
   ansible.builtin.apt:
-    name: cron
+    name:
+      - cron
+      - ansible
+    update_cache: "{{ onprem_ansible_ppa.changed }}"
+    cache_valid_time: 60
 - name: Run ansible-pull periodically
   ansible.builtin.cron:
     name: ansible-pull

--- a/linux/roles/onprem/tasks/needs-restart.yml
+++ b/linux/roles/onprem/tasks/needs-restart.yml
@@ -1,10 +1,9 @@
 ---
 - name: Ensure packages are present
   ansible.builtin.apt:
-    name: "{{ item }}"
-  loop:
-    - cron
-    - needrestart
+    name:
+      - cron
+      - needrestart
 - name: Run needrestart daily
   ansible.builtin.cron:
     name: needrestart

--- a/linux/roles/splunk/tasks/main.yml
+++ b/linux/roles/splunk/tasks/main.yml
@@ -36,6 +36,7 @@
     ignore_nonexistent_bucket: true
 - name: Expand Splunkcloud configuration
   ansible.builtin.unarchive:
+    creates: /opt/splunkforwarder/etc/deployment-apps/splunkclouduf.spl
     owner: splunk
     group: splunk
     src: /opt/splunkforwarder/etc/deployment-apps/splunkclouduf.spl


### PR DESCRIPTION
- only update the cache if the relevant repo was added
- pass list to `name` rather than looping
- only unzip Splunk configuration once