### PR TITLE
fix: change path for detecting ECS Anywhere

### DIFF
--- a/linux/roles/ecs_anywhere/tasks/main.yml
+++ b/linux/roles/ecs_anywhere/tasks/main.yml
@@ -116,7 +116,7 @@
       --cluster {{ ecs_anywhere_cluster }}
       --activation-id {{ ecs_anywhere_activation_id | trim | quote }}
       --activation-code {{ ecs_anywhere_activation_code | trim | quote }}
-    creates: /etc/init/amazon-ssm-agent.conf
+    creates: /usr/libexec/amazon-ecs-init
 - name: Configure ECS Anywhere
   ansible.builtin.template:
     owner: root


### PR DESCRIPTION
This is the path that the ECS Anywhere install script checks to see if the install has already happened. For some reason, `/etc/init/amazon-ssm-agent.conf` is not always created.