### PR TITLE
fix: update the cache as a part of installing the PPA

### DIFF
--- a/linux/roles/onprem/tasks/ansible-pull.yml
+++ b/linux/roles/onprem/tasks/ansible-pull.yml
@@ -19,6 +19,7 @@
   register: onprem_ansible_ppa
   ansible.builtin.apt_repository:
     repo: "ppa:ansible/ansible"
+    update_cache: true
     # matches what's generated from cloud-init/user-data
     filename: "ansible-ubuntu-ansible-jammy"
 - name: Ensure packages are present
@@ -26,8 +27,6 @@
     name:
       - cron
       - ansible
-    update_cache: "{{ onprem_ansible_ppa.changed }}"
-    cache_valid_time: 60
 - name: Run ansible-pull periodically
   ansible.builtin.cron:
     name: ansible-pull


### PR DESCRIPTION
This avoids needing to re-update the cache when installing cron/Ansible.

Asana: https://app.asana.com/0/1113545750913664/1205309479399573/f