### PR TITLE
Chore: Update GitHub actions to use assumed role

### DIFF
--- a/.github/workflows/deploy_document.yml
+++ b/.github/workflows/deploy_document.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   update:
     runs-on: ubuntu-latest
+    permissions: 
+      id-token: write
+      contents: read
     env:
       AWS_REGION: us-east-1
       DOCUMENT_NAME: mbta-pull-ecr-stack-deploy
@@ -15,10 +18,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
       - id: update_document
         run: |


### PR DESCRIPTION
This PR updates the deploy workflow to use v2 of the shared `build-push-ecr` and `deploy-ecs` actions. These updated actions assume an IAM role instead of relying on long-lasting AWS keys for an IAM user