### PR TITLE
fix: disable failing Vagrant CI check

### DIFF
--- a/.github/workflows/vagrant-up.yml
+++ b/.github/workflows/vagrant-up.yml
@@ -1,9 +1,12 @@
 name: vagrant-up
 
 on:
-  push:
-    paths:
-      - linux/**
+  workflow_dispatch:
+  # disabled due to consistent failures on macOS runners
+  # https://github.com/actions/runner-images/issues/8730
+  # push:
+  #   paths:
+  #     - linux/**
 
 jobs:
   vagrant-up:


### PR DESCRIPTION
The "vagrant-up" CI check hasn't been working for a while. I investigated and found [this GitHub issue](https://github.com/actions/runner-images/issues/8730) that implies the issue lies with the macOS runner, and persists despite some attempts to fix it.

Let's set this check to only run manually for now, and test changes locally as needed.