### PR TITLE
feat: Add role vars to optionally disable certain tasks

### DIFF
--- a/linux/group_vars/local/service_registration.yml
+++ b/linux/group_vars/local/service_registration.yml
@@ -1,0 +1,7 @@
+# skip tasks that register the instance to external systems
+---
+
+ecs_anywhere_activate: false
+crowdstrike_configure_falcon_sensor: false
+splunk_enable_forwarding: false
+tenable_link_nessus_agent: false

--- a/linux/roles/crowdstrike/defaults/main.yml
+++ b/linux/roles/crowdstrike/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+crowdstrike_configure_falcon_sensor: true
 crowdstrike_version: "6.51.0-14812"
 crowdstrike_path: "falcon-sensor_{{ crowdstrike_version }}_amd64.deb"
 crowdstrike_cid: !vault |

--- a/linux/roles/crowdstrike/tasks/main.yml
+++ b/linux/roles/crowdstrike/tasks/main.yml
@@ -18,12 +18,13 @@
   ansible.builtin.apt:
     deb: /root/falcon-sensor.deb
 - name: Configure Falcon sensor
-  when: crowdstrike_install.changed # noqa: no-handler
+  when: crowdstrike_install.changed and crowdstrike_configure_falcon_sensor is true  # noqa: no-handler
   register: crowdstrike_configure
   failed_when: crowdstrike_configure.rc > 0 and crowdstrike_configure.rc < 255
   changed_when: crowdstrike_configure.rc == 0
   ansible.builtin.command: /opt/CrowdStrike/falconctl -s --cid={{ crowdstrike_cid | trim | quote }}
 - name: Ensure falcon-sensor is running
+  when: crowdstrike_configure_falcon_sensor is true
   ansible.builtin.service:
     name: falcon-sensor
     state: started

--- a/linux/roles/ecs_anywhere/defaults/main.yml
+++ b/linux/roles/ecs_anywhere/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 
+ecs_anywhere_activate: true
 ecs_anywhere_aws_gpg_key: BCE9D9A42D51784F
 ecs_anywhere_install_prefix: "https://amazon-ecs-agent.s3.amazonaws.com"
 ecs_anywhere_region: us-east-2

--- a/linux/roles/ecs_anywhere/tasks/install-ecs-agent.yml
+++ b/linux/roles/ecs_anywhere/tasks/install-ecs-agent.yml
@@ -54,7 +54,8 @@
 - name: Install ECS Anywhere
   when: |
     ecs_anywhere_activation_id is defined and
-    ecs_anywhere_activation_code is defined
+    ecs_anywhere_activation_code is defined and
+    ecs_anywhere_activate is true
   changed_when: false
   ansible.builtin.command:
     cmd: >-
@@ -73,6 +74,7 @@
     mode: '0644'
   notify: ECS agent
 - name: SSM is running
+  when: ecs_anywhere_activate is true
   ansible.builtin.service:
     name: amazon-ssm-agent
     state: started

--- a/linux/roles/ecs_anywhere/tasks/main.yml
+++ b/linux/roles/ecs_anywhere/tasks/main.yml
@@ -7,6 +7,8 @@
 - name: Install AWSCLI
   ansible.builtin.include_tasks: install-awscli.yml
 - name: Create Ansible Facts
+  when: ecs_anywhere_activate is true
   ansible.builtin.include_tasks: create-facts.yml
 - name: Write ECS Attributes
+  when: ecs_anywhere_activate is true
   ansible.builtin.include_tasks: write-ecs-attributes.yml

--- a/linux/roles/splunk/defaults/main.yml
+++ b/linux/roles/splunk/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+splunk_enable_forwarding: true
 splunk_version: "9.0.4"
 splunk_deb: "splunkforwarder-{{ splunk_version }}-de405f4a7979-linux-2.6-amd64.deb"
 splunk_index: test

--- a/linux/roles/splunk/tasks/main.yml
+++ b/linux/roles/splunk/tasks/main.yml
@@ -3,4 +3,5 @@
 - name: Install and configure Splunk
   ansible.builtin.include_tasks: install-splunk.yml
 - name: Set up Splunk forwarding
+  when: splunk_enable_forwarding is true
   ansible.builtin.include_tasks: set-up-splunk-forwarding.yml

--- a/linux/roles/tenable/defaults/main.yml
+++ b/linux/roles/tenable/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+tenable_link_nessus_agent: true
 tenable_version: "10.4.0"
 tenable_path: "NessusAgent-{{ tenable_version }}-ubuntu1404_amd64.deb"
 tenable_key: !vault |

--- a/linux/roles/tenable/tasks/main.yml
+++ b/linux/roles/tenable/tasks/main.yml
@@ -18,7 +18,7 @@
   ansible.builtin.apt:
     deb: /root/nessus.deb
 - name: Configure Nessus
-  when: tenable_install.changed # noqa: no-handler
+  when: tenable_install.changed and tenable_link_nessus_agent is true  # noqa: no-handler
   changed_when: false
   ansible.builtin.command: >-
     /opt/nessus_agent/sbin/nessuscli agent link


### PR DESCRIPTION
Some roles (CrowdStrike, ECS Anywhere, Splunk, Tenable) contain tasks that register or call out to other systems. These can make testing of the overall Ansible configuration difficult, so it's useful to have the option to disable those callouts when testing.