### PR TITLE
feat: Support provisioning base images for Splunk servers

### DIFF
--- a/linux/build_ova.sh
+++ b/linux/build_ova.sh
@@ -15,7 +15,7 @@ VMDK_URL=https://cloud-images.ubuntu.com/releases/jammy/release/"$VMDK_PATH"
 HOSTNAME=${1:-local01}
 IP_ADDRESS=$2
 
-tmpdir=$(realpath tmp) # ignored by .gitignore
+tmpdir="tmp" # ignored by .gitignore
 mkdir -p "$tmpdir"
 
 pushd "$tmpdir" > /dev/null

--- a/linux/group_vars/splunk_base_image/users.yml
+++ b/linux/group_vars/splunk_base_image/users.yml
@@ -1,0 +1,8 @@
+# prod users
+---
+
+users:
+  - username: rkuthuru
+    comment: Raj Kuthuru
+    github: rkuthuru12
+    groups: [admin, users]

--- a/linux/inventory.yml
+++ b/linux/inventory.yml
@@ -32,3 +32,14 @@ prod:
         com.mbta.ctd.primary-instance:
     HSCTDLNXPRD[02:99]:
     PPCTDLNXPRD[01:99]:
+
+splunk_base_image:
+  children:
+    splunk_heavy_forwarder:
+      hosts:
+        HSSPLNKHF[01:99]:
+        PPSPLNKHF[01:99]:
+    splunk_deployment_server:
+      hosts:
+        HSSPLNKDS[01:99]:
+        PPSPLNKDS[01:99]:

--- a/linux/main.yml
+++ b/linux/main.yml
@@ -74,3 +74,14 @@
     - role: metrics
     - role: crowdstrike
     - role: tenable
+
+
+- name: Splunk base image
+  hosts: splunk_base_image
+  roles:
+    - role: pull
+    - role: users
+    - role: onprem
+      tags: [initial]
+    - role: crowdstrike
+    - role: tenable


### PR DESCRIPTION
Tested in QEMU and confirmed that it provisions successfully.

@rkuthuru12 to build images:

1. Clone this repo
2. If this PR isn't merged yet, switch to `idw-splunk-hf` branch
3. Run:
   ```bash
   cd linux/
   bash ./build_ova.sh <hostname> <ip_address>
   ```
4. Repeat step 3 for each server image
5. Share `tmp/<hostname>.ova` files with infrastructure team for provisioning

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206851728384043