### PR TITLE
fix: remove unused dpkg task

### DIFF
--- a/linux/roles/ecs_anywhere/tasks/install-docker.yml
+++ b/linux/roles/ecs_anywhere/tasks/install-docker.yml
@@ -46,12 +46,6 @@
     group: root
     mode: '0644'
 
-# TODO remove this task as it's no longer needed
-- name: Allow upgrading Docker package
-  ansible.builtin.dpkg_selections:
-    name: docker-ce
-    selection: install
-
 - name: Ensure new Docker packages are installed
   ansible.builtin.apt:
     name:


### PR DESCRIPTION
I ran into an issue with this when configuring HSCTDLNXSTG02, where it complained that docker-ce wasn't installed first.