### PR TITLE
Updated splunk forwarder deb package

### DIFF
--- a/linux/roles/splunk/defaults/main.yml
+++ b/linux/roles/splunk/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 
 splunk_enable_forwarding: true
-splunk_version: "9.0.4"
-splunk_deb: "splunkforwarder-{{ splunk_version }}-de405f4a7979-linux-2.6-amd64.deb"
+splunk_version: "9.3.0"
+splunk_deb: "splunkforwarder-{{ splunk_version }}-51ccf43db5bd-linux-2.6-amd64.deb"
 splunk_index: test
 splunk_forwarder_collectd_https_port: 9556  # randomly generated
 splunk_forwarder_collectd_index: collectd-metrics

--- a/linux/roles/splunk/tasks/install-splunk.yml
+++ b/linux/roles/splunk/tasks/install-splunk.yml
@@ -21,7 +21,7 @@
     url: "https://{{ s3_config_bucket }}.s3.amazonaws.com/{{ s3_package_prefix }}/{{ splunk_deb }}"
     dest: "/home/splunk/{{ splunk_deb }}"
     mode: '0644'
-    checksum: "sha256:21fdd8c5af99f47fa8a2a7a1c2771491371fbf3bb83c854c9b82b55caf0e1588"
+    checksum: "sha256:87db540f35d5318ee218cb7c6a14cb7bc11a26f08e5ddc663dfed7a4497c3b3c"
 
 - name: Install Splunk universal forwarder
   when: splunk_download.changed  # noqa: no-handler


### PR DESCRIPTION
Linux Splunk Universal Forwarder Upgrade
https://app.asana.com/0/1113545750913664/1207115331926304

I downloaded the latest debian package for the universal forwarder and uploaded it to the linux-onprem S3 bucket.

Updated to: splunkforwarder-9.3.0-51ccf43db5bd-linux-2.6-amd64.deb

I had to update the SHA256 checksum:
sha256sum splunkforwarder-9.3.0-51ccf43db5bd-linux-2.6-amd64.deb
87db540f35d5318ee218cb7c6a14cb7bc11a26f08e5ddc663dfed7a4497c3b3c  splunkforwarder-9.3.0-51ccf43db5bd-linux-2.6-amd64.deb

That was generated on an Ubuntu 22 machine.