### PR TITLE
install SSM agent on SCUs

### DIFF
--- a/linux/roles/scu/tasks/main.yml
+++ b/linux/roles/scu/tasks/main.yml
@@ -8,3 +8,35 @@
   ansible.builtin.apt:
     name:
       - asihpi-dkms-4
+
+- name: Install SSM Agent
+  community.general.snap:
+    name:
+      - amazon-ssm-agent
+
+- name: Check SSM registration
+  ansible.builtin.stat:
+    path: /var/lib/amazon/ssm/registration
+  register: ssm_registration
+
+- name: Stop SSM Agent
+  ansible.builtin.systemd_service:
+    name: snap.amazon-ssm-agent.amazon-ssm-agent.service
+    state: stopped
+  when: not ssm_registration.stat.exists
+
+- name: Register SSM Agent
+  ansible.builtin.command:
+    cmd: >-
+      /snap/amazon-ssm-agent/current/amazon-ssm-agent -register
+      -code {{ lookup('file', '/root/activation-code') }}
+      -id {{ lookup('file', '/root/activation-id') }}
+      -region us-east-1
+  changed_when: true
+  when: not ssm_registration.stat.exists
+
+- name: Start SSM Agent
+  ansible.builtin.systemd_service:
+    name: snap.amazon-ssm-agent.amazon-ssm-agent.service
+    state: started
+  when: not ssm_registration.stat.exists


### PR DESCRIPTION
This installs the SSM agent on SCUs, using the activation id and code deposited by the custom script on the installation image.