### PR TITLE
Add wjohnson user to linux on prem

### DIFF
--- a/linux/group_vars/staging/users.yml
+++ b/linux/group_vars/staging/users.yml
@@ -18,3 +18,7 @@ users:
     comment: Raj Kuthuru
     github: rkuthuru12
     groups: [admin, users, docker]
+  - username: wjohnson
+    comment: Warren Johnson
+    github: Warren-Johnson-TID
+    groups: [admin, users, docker]


### PR DESCRIPTION
Adding Warren Johnson user "wjohnson" to Linux on prem servers.  Public key pulled from https://github.com/Warren-Johnson-TID