### PR TITLE
Allow apt on linux staging to downgrade package versions

### DIFF
--- a/linux/roles/splunk/tasks/install-splunk.yml
+++ b/linux/roles/splunk/tasks/install-splunk.yml
@@ -28,7 +28,7 @@
   register: splunk_install
   ansible.builtin.apt:
     deb: "/home/splunk/{{ splunk_deb }}"
-    allow_downgrade: yes
+    allow_downgrade: "yes"
 
 - name: Generate local Splunk admin password
   ansible.builtin.shell:

--- a/linux/roles/splunk/tasks/install-splunk.yml
+++ b/linux/roles/splunk/tasks/install-splunk.yml
@@ -28,6 +28,7 @@
   register: splunk_install
   ansible.builtin.apt:
     deb: "/home/splunk/{{ splunk_deb }}"
+    allow_downgrade: yes
 
 - name: Generate local Splunk admin password
   ansible.builtin.shell:


### PR DESCRIPTION
on_prem linux staging doesn't seem to be able to downgrade the Splunk Universal Forwarder from 9.3.0 to 9.0.4.  Adding "allow_downgrade: yes" to the Spunk Installer should fix that