### PR TITLE
add systemd unit to run Scully

### DIFF
--- a/linux/README.md
+++ b/linux/README.md
@@ -103,3 +103,18 @@ should not be public but are not otherwise secret inside the MBTA.
 While they are encrypted, long-term credentials (such as AWS access keys or
 passwords) should not be stored with `ansible-vault encrypt`. Instead, fetch
 those credentials from a more secure source, such as S3 using SSM credentials.
+
+# SCU installer
+
+To create an SCU installation USB drive:
+
+Install the `xorriso` package using your system's package manager.
+
+Download an [Ubuntu Server 22.04](https://ubuntu.com/download/server) image.
+
+Create the installer image with the following command. To create an installer for the test environments, add the `--staging` option
+``` shell
+./build_scu_iso --input PATH_TO_UBUNTU_IMAGE
+```
+
+Write `tmp/output.iso` to the USB drive with your tool of choice.

--- a/linux/SCU.md
+++ b/linux/SCU.md
@@ -1,0 +1,41 @@
+# SCU installation instructions
+This document describes the process for installing MBTA software on a System Control Unit (SCU) server.
+
+## Required items and information
+* SCU installation USB drive
+* SCU-specific configuration values
+    * Name
+    * Subnet
+    * Address
+    * Gateway
+    * Nameserver
+* SCU activation password
+
+## Steps
+1. Insert the SCU installation USB drive into the machine.
+1. Boot/reboot the machine, holding down the F2/Del key until you reach the BIOS screen:
+    1. Change the first boot option to the USB device.
+    1. Save changes and exit, which will cause the machine to reboot.
+1. Wait until you reach the "GNU GRUB" menu:
+    1. Select "Try or Install Ubuntu Server", or wait 30 seconds which will automatically select that option.
+1. Wait until you reach the "Network connections" screen:
+    1. Select the first ethernet device.
+    1. Select "Edit IPv4".
+    1. Change "IPv4 Method" to "Manual".
+    1. Fill out the "Subnet", "Address", "Gateway", and "Nameserver" fields with the provided values for this SCU.
+    1. Press "Save".
+    1. Press "Done" to complete this screen.
+1. On the "Profile setup" screen:
+    1. Set "Your servers name" to the provided value for this SCU (use lowercase letters).
+    1. Set "Choose a password" and "Confirm your password" to `ubuntu`.
+    1. Press "Done" to complete this screen.
+1. At the "Confirm destructive action" prompt, press "Continue".
+1. Wait until the button at the bottom changes to "Reboot Now", but do NOT press it yet. This will take several minutes.
+1. Press the F2 key to open a command prompt:
+    1. Type `/cdrom/activate-scu` and press Enter.
+    1. When prompted, type the provided SCU activation password and press Enter.
+    1. Confirm that you see a success message.
+    1. Type `exit` and press Enter to return to the installer.
+1. Press "Reboot Now"
+1. At the prompt to "Please remove the installation medium, then press ENTER", follow those instructions.
+1. The system will reboot and perform the rest of the setup automatically.

--- a/linux/group_vars/scu/env.yml
+++ b/linux/group_vars/scu/env.yml
@@ -1,0 +1,4 @@
+---
+
+scu_env: prod
+scu_autostart: true

--- a/linux/inventory.yml
+++ b/linux/inventory.yml
@@ -149,4 +149,8 @@ scu:
     SDUDSCU001:
     SEAVSCU001:
     SWTCSCU001:
-    TESTSCU[001:999]:
+    TESTSCU[001:899]:
+      scu_env: staging
+    TESTSCU[900:999]:
+      scu_env: staging
+      scu_autostart: false

--- a/linux/roles/scu/files/scully.service
+++ b/linux/roles/scu/files/scully.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Scully service
+After=docker.service
+Requires=docker.service
+
+[Service]
+TimeoutStartSec=0
+Restart=always
+ExecStart=/root/run-scully
+
+[Install]
+WantedBy=default.target

--- a/linux/roles/scu/tasks/main.yml
+++ b/linux/roles/scu/tasks/main.yml
@@ -4,10 +4,11 @@
   ansible.builtin.apt_repository:
     repo: "ppa:audioscience/release"
 
-- name: Ensure AudioScience drivers are installed
+- name: Install packages
   ansible.builtin.apt:
     name:
       - asihpi-dkms-4
+      - awscli
 
 - name: Install SSM Agent
   community.general.snap:
@@ -38,9 +39,28 @@
 - name: Start SSM Agent
   ansible.builtin.systemd_service:
     name: snap.amazon-ssm-agent.amazon-ssm-agent.service
+    enabled: true
     state: started
-  when: not ssm_registration.stat.exists
 
 - name: Install Docker
   ansible.builtin.include_role:
     name: docker
+
+- name: Write scully systemd unit
+  ansible.builtin.copy:
+    src: scully.service
+    dest: /etc/systemd/system/scully.service
+    mode: "0644"
+
+- name: Write scully startup script
+  ansible.builtin.template:
+    src: run-scully.j2
+    dest: /root/run-scully
+    mode: "0755"
+
+- name: Enable and start systemd unit
+  ansible.builtin.systemd_service:
+    name: scully.service
+    enabled: true
+    state: started
+  when: scu_autostart

--- a/linux/roles/scu/templates/run-scully.j2
+++ b/linux/roles/scu/templates/run-scully.j2
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e
+
+SERVER=434035161053.dkr.ecr.us-east-1.amazonaws.com
+IMAGE=$SERVER/scully:{{ scu_env }}
+CONTAINER=scully
+
+docker stop $CONTAINER || true
+docker rm $CONTAINER || true
+aws ecr get-login-password --region us-east-1 \
+    | docker login --username AWS --password-stdin $SERVER
+docker pull $IMAGE
+API_KEY=$(aws secretsmanager get-secret-value \
+    --secret-id scully-{{ scu_env }}-api-key \
+    --region us-east-1 \
+    --query "SecretString" \
+    --output text)
+docker run --rm --name $CONTAINER \
+    --device=/dev/asihpi:/dev/asihpi \
+    -p 80:80 \
+    --env SCULLY_STATION_ID=$(hostname) \
+    --env SCULLY_API_KEY=$API_KEY \
+    $IMAGE


### PR DESCRIPTION
This adds a systemd unit and shell script to update and run Scully. Also adds instructions for creating the installation USB, and instructions for doing an actual install. Verified on my test machine.