### PR TITLE
Fix: Include Prune Task in main.yml

### DIFF
--- a/linux/roles/docker/tasks/main.yml
+++ b/linux/roles/docker/tasks/main.yml
@@ -57,3 +57,7 @@
     state: present
     update_cache: "{{ add_docker_repo.changed }}"
     cache_valid_time: 60
+
+- name: Prune resources weekly
+  ansible.builtin.include_tasks:
+    file: prune-docker.yml


### PR DESCRIPTION
@ianwestcott [commented](https://github.com/mbta/on_prem_deploy/pull/71#issuecomment-2334278576) in #71 that I need to add an `include_tasks` block for this to run automatically. I referred to the [Ansible docs](https://docs.ansible.com/ansible/5/collections/ansible/builtin/include_tasks_module.html#ansible-collections-ansible-builtin-include-tasks-module) here; happy to adjust as needed but I didn't include any tags or conditions. 