### PR TITLE
set SCU audio mode on app startup

### DIFF
--- a/linux/roles/scu/templates/run-scully.j2
+++ b/linux/roles/scu/templates/run-scully.j2
@@ -17,6 +17,13 @@ API_KEY=$(aws secretsmanager get-secret-value \
     --query "SecretString" \
     --output text)
 docker run --rm --name $CONTAINER \
+    --privileged \
+    --device=/dev/asihpi:/dev/asihpi \
+    --env SCULLY_STATION_ID=$(hostname) \
+    --env SCULLY_API_KEY=$API_KEY \
+    $IMAGE \
+    /scully/bin/scully eval "AudioTasks.set_audio_mode()"
+docker run --rm --name $CONTAINER \
     --device=/dev/asihpi:/dev/asihpi \
     -p 80:80 \
     --env SCULLY_STATION_ID=$(hostname) \


### PR DESCRIPTION
This calls a setup task to switch the SCU audio card to mono mode, before running the app. This needs to be handled separately, because switching modes requires a hardware reset on the audio card, which is a privileged operation.