### PR TITLE
fix SCU installation scripts

### DIFF
--- a/linux/build_scu_iso
+++ b/linux/build_scu_iso
@@ -16,7 +16,7 @@ with open('tmp/autoinstall.yaml', mode='w') as f:
   f.write(f"""\
 {open('scu/autoinstall.yaml').read()}
 user-data:
-{re.sub(r'(?m)^', '  ', subprocess.run(['bash', 'build_user_data.sh'], capture_output=True, text=True).stdout)}
+{re.sub(r'(?m)^', '  ', subprocess.run(['bash', 'build_user_data.sh'], capture_output=True, text=True, check=True).stdout)}
 """)
 
 if args.staging:

--- a/linux/build_user_data.sh
+++ b/linux/build_user_data.sh
@@ -10,5 +10,5 @@ fi
 
 < cloud-init/user-data \
 sed "s/GITHUB_REPO/${GITHUB_REPO/\//\\/}/g" \
-| sed "s/GIT_BRANCH/$GIT_BRANCH/g" \
+| sed "s/GIT_BRANCH/${GIT_BRANCH/\//\\/}/g" \
 | sed "s/ANSIBLE_VAULT_PASSWORD/$ANSIBLE_VAULT_PASSWORD/g" \

--- a/linux/group_vars/scu/users.yml
+++ b/linux/group_vars/scu/users.yml
@@ -5,20 +5,20 @@ users:
   - username: pswartz
     comment: Paul Swartz
     github: paulswartz
-    groups: [sudo, users]
+    groups: [admin, users]
   - username: iwestcott
     comment: Ian Westcott
     github: ianwestcott
-    groups: [sudo, users]
+    groups: [admin, users]
   - username: krisjohnson
     comment: Kris Johnson
     github: krisrjohnson21
-    groups: [sudo, users]
+    groups: [admin, users]
   - username: bheathwlaz
     comment: Brett Heath-Wlaz
     github: panentheos
-    groups: [sudo, users]
+    groups: [admin, users]
   - username: pkim
     comment: Paul Kim
     github: PaulJKim
-    groups: [sudo, users]
+    groups: [admin, users]

--- a/linux/roles/scu/tasks/main.yml
+++ b/linux/roles/scu/tasks/main.yml
@@ -12,8 +12,8 @@
 
 - name: Install SSM Agent
   community.general.snap:
-    name:
-      - amazon-ssm-agent
+    name: amazon-ssm-agent
+    classic: true
 
 - name: Check SSM registration
   ansible.builtin.stat:

--- a/linux/scu/autoinstall.yaml
+++ b/linux/scu/autoinstall.yaml
@@ -7,5 +7,8 @@ identity:
   username: ubuntu
   password: ""
   hostname: ""
+ssh:
+  install-server: true
+  allow-pw: false
 late-commands:
   - sed -i "s/\(.*\)/\U\1/g" /target/etc/hostname


### PR DESCRIPTION
Fixes a few issues that came up during testing of the SCU install process.

* Makes the ISO build script fail loudly on errors
* Allows specifying git branches with slashes
* Adds users to the `admin` group for sudo privileges
* Uses the `classic` flag to install the SSM agent
* Installs the SSH server on SCUs

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208422519448697