### PR TITLE
add screens team users and fix docker installation

### DIFF
--- a/linux/group_vars/scu/users.yml
+++ b/linux/group_vars/scu/users.yml
@@ -5,28 +5,28 @@ users:
   - username: pswartz
     comment: Paul Swartz
     github: paulswartz
-    groups: [admin, users]
+    groups: [admin, users, docker]
   - username: iwestcott
     comment: Ian Westcott
     github: ianwestcott
-    groups: [admin, users]
+    groups: [admin, users, docker]
   - username: krisjohnson
     comment: Kris Johnson
     github: krisrjohnson21
-    groups: [admin, users]
+    groups: [admin, users, docker]
   - username: bheathwlaz
     comment: Brett Heath-Wlaz
     github: panentheos
-    groups: [admin, users]
+    groups: [admin, users, docker]
   - username: pkim
     comment: Paul Kim
     github: PaulJKim
-    groups: [admin, users]
+    groups: [admin, users, docker]
   - username: cgrant2
     comment: Cora Grant
     github: digitalcora
-    groups: [admin, users]
+    groups: [admin, users, docker]
   - username: cmaddox
     comment: Christian Maddox
     github: cmaddox5
-    groups: [admin, users]
+    groups: [admin, users, docker]

--- a/linux/group_vars/scu/users.yml
+++ b/linux/group_vars/scu/users.yml
@@ -22,3 +22,11 @@ users:
     comment: Paul Kim
     github: PaulJKim
     groups: [admin, users]
+  - username: cgrant2
+    comment: Cora Grant
+    github: digitalcora
+    groups: [admin, users]
+  - username: cmaddox
+    comment: Christian Maddox
+    github: cmaddox5
+    groups: [admin, users]

--- a/linux/roles/docker/tasks/main.yml
+++ b/linux/roles/docker/tasks/main.yml
@@ -38,13 +38,9 @@
   changed_when: false
 
 - name: Add Docker repo to apt
-  register: add_docker_repo
-  ansible.builtin.copy:
-    content: "{{ docker_list.stdout }}"
-    dest: /etc/apt/sources.list.d/docker.list
-    owner: root
-    group: root
-    mode: '0644'
+  ansible.builtin.apt_repository:
+    repo: "{{ docker_list.stdout }}"
+    filename: docker
 
 - name: Ensure new Docker packages are installed
   ansible.builtin.apt:
@@ -54,9 +50,6 @@
       - containerd.io
       - docker-buildx-plugin
       - docker-compose-plugin
-    state: present
-    update_cache: "{{ add_docker_repo.changed }}"
-    cache_valid_time: 60
 
 - name: Prune resources weekly
   ansible.builtin.include_tasks:


### PR DESCRIPTION
This adds the other screens team members as SCU users so they can log in as well. Adds all users to the `docker` group.

Also changes the docker installation steps to use a more standard pattern for adding the apt repo. I saw an intermittent failure on this step, where the package wasn't found, and it seemed like a timing issue around updating apt after adding the repo. Using the `apt_repository` builtin should behave better and handle the update automatically.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208568231374247