### PR TITLE
fix scully port mapping

### DIFF
--- a/linux/roles/scu/templates/run-scully.j2
+++ b/linux/roles/scu/templates/run-scully.j2
@@ -25,7 +25,7 @@ docker run --rm --name $CONTAINER \
     /scully/bin/scully eval "AudioTasks.set_audio_mode()"
 docker run --rm --name $CONTAINER \
     --device=/dev/asihpi:/dev/asihpi \
-    -p 80:80 \
+    -p 80:4010 \
     --env SCULLY_STATION_ID=$(hostname) \
     --env SCULLY_API_KEY=$API_KEY \
     $IMAGE


### PR DESCRIPTION
This fixes the port mapping for the Scully container. The service will run on port 4010 internally, so we map to that.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208600087427249