### PR TITLE
pass splunk token in Scully environment

### DIFF
--- a/linux/roles/scu/templates/run-scully.j2
+++ b/linux/roles/scu/templates/run-scully.j2
@@ -6,21 +6,29 @@ SERVER={{ aws_account_id }}.dkr.ecr.{{ aws_region }}.amazonaws.com
 IMAGE=$SERVER/scully:{{ scu_env }}
 CONTAINER=scully
 
+read_secret() {
+    aws secretsmanager get-secret-value \
+        --secret-id $1 \
+        --region {{ aws_region }} \
+        --query "SecretString" \
+        --output text
+}
+
 docker stop $CONTAINER || true
 docker rm $CONTAINER || true
 aws ecr get-login-password --region {{ aws_region }} \
     | docker login --username AWS --password-stdin $SERVER
 docker pull $IMAGE
-API_KEY=$(aws secretsmanager get-secret-value \
-    --secret-id scully-{{ scu_env }}-api-key \
-    --region {{ aws_region }} \
-    --query "SecretString" \
-    --output text)
+API_KEY=$(read_secret scully-{{ scu_env }}-api-key)
+SPLUNK_TOKEN=$(read_secret lambda-generic-splunk-token)
+SPLUNK_INDEX=scully-{{ scu_env }}
 docker run --rm --name $CONTAINER \
     --privileged \
     --device=/dev/asihpi:/dev/asihpi \
     --env SCULLY_STATION_ID=$(hostname) \
     --env SCULLY_API_KEY=$API_KEY \
+    --env SCULLY_SPLUNK_INDEX=$SPLUNK_INDEX \
+    --env SPLUNK_TOKEN=$SPLUNK_TOKEN \
     $IMAGE \
     /scully/bin/scully eval "AudioTasks.set_audio_mode()"
 docker run --rm --name $CONTAINER \
@@ -28,4 +36,6 @@ docker run --rm --name $CONTAINER \
     -p 80:4010 \
     --env SCULLY_STATION_ID=$(hostname) \
     --env SCULLY_API_KEY=$API_KEY \
+    --env SCULLY_SPLUNK_INDEX=$SPLUNK_INDEX \
+    --env SPLUNK_TOKEN=$SPLUNK_TOKEN \
     $IMAGE


### PR DESCRIPTION
This reads the Splunk token from secrets manager and passes it via the environment to the Scully container.