### PR TITLE
fix inventory for prod-like test SCU

### DIFF
--- a/linux/inventory.yml
+++ b/linux/inventory.yml
@@ -149,7 +149,8 @@ scu:
     SDUDSCU001:
     SEAVSCU001:
     SWTCSCU001:
-    TESTSCU[001:899]:
+    TESTSCU[001:099]:
+    TESTSCU[100:899]:
       scu_env: staging
     TESTSCU[900:999]:
       scu_env: staging

--- a/linux/roles/scu/files/scully.service
+++ b/linux/roles/scu/files/scully.service
@@ -2,10 +2,12 @@
 Description=Scully service
 After=docker.service
 Requires=docker.service
+StartLimitIntervalSec=0
 
 [Service]
 TimeoutStartSec=0
 Restart=always
+RestartSec=10
 ExecStart=/root/run-scully
 
 [Install]


### PR DESCRIPTION
This changes a range of test SCU hostnames to use the `prod` environment, so we can conduct our in-office test. This won't affect anything actually in the field. Also changes some settings for the application systemd unit, so that it never gives up trying to restart itself on failure, but with a short delay so it doesn't thrash.