### PR TITLE
chore: update SSH key and prod hostnames

### DIFF
--- a/linux/cloud-init/user-data
+++ b/linux/cloud-init/user-data
@@ -19,7 +19,7 @@ users:
   - name: ubuntu
     sudo: "ALL=(ALL) NOPASSWD:ALL"
     ssh_authorized_keys:
-      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOV3T6Da+IyAFLcND2qAeuTdtrKUUJCL2zaastUNQ5je
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBCjUF91KR24vSxdet//lijSSayNkWzsVNyILOsxIeOm
 
 write_files:
   - path: /root/.ansible_vault_password

--- a/linux/cloud-init/user-data
+++ b/linux/cloud-init/user-data
@@ -16,7 +16,7 @@ ssh:
 
 # Provide a key for the default Ubuntu user as a failsafe. Ansible will delete it once the other users are set up.
 users:
-  - name: ubuntu
+  - name: on_prem_deploy cloud-init SSH key
     sudo: "ALL=(ALL) NOPASSWD:ALL"
     ssh_authorized_keys:
       - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBCjUF91KR24vSxdet//lijSSayNkWzsVNyILOsxIeOm

--- a/linux/cloud-init/user-data
+++ b/linux/cloud-init/user-data
@@ -16,7 +16,7 @@ ssh:
 
 # Provide a key for the default Ubuntu user as a failsafe. Ansible will delete it once the other users are set up.
 users:
-  - name: on_prem_deploy cloud-init SSH key
+  - name: ubuntu
     sudo: "ALL=(ALL) NOPASSWD:ALL"
     ssh_authorized_keys:
       - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBCjUF91KR24vSxdet//lijSSayNkWzsVNyILOsxIeOm

--- a/linux/inventory.yml
+++ b/linux/inventory.yml
@@ -32,6 +32,7 @@ prod:
         com.mbta.ctd.primary-instance:
     HSCTDLNXPRD[02:99]:
     PPCTDLNXPRD[01:99]:
+    MLLTIDAPP[01:99]P:
 
 splunk_base_image:
   children:

--- a/linux/inventory.yml
+++ b/linux/inventory.yml
@@ -32,7 +32,7 @@ prod:
         com.mbta.ctd.primary-instance:
     HSCTDLNXPRD[02:99]:
     PPCTDLNXPRD[01:99]:
-    MLLTIDAPP01P:
+    MLLTIDAPP[01:99]P:
 
 splunk_base_image:
   children:

--- a/linux/inventory.yml
+++ b/linux/inventory.yml
@@ -32,7 +32,7 @@ prod:
         com.mbta.ctd.primary-instance:
     HSCTDLNXPRD[02:99]:
     PPCTDLNXPRD[01:99]:
-    MLLTIDAPP[01:99]P:
+    MLLTIDAPP01P:
 
 splunk_base_image:
   children:

--- a/linux/roles/ansible/tasks/main.yml
+++ b/linux/roles/ansible/tasks/main.yml
@@ -20,6 +20,11 @@
     name: amazon-ssm-agent
     classic: true
 
+- name: Check SSM registration
+  ansible.builtin.stat:
+    path: /var/lib/amazon/ssm/registration
+  register: ssm_registration
+
 - name: Register SSM Agent
   ansible.builtin.command:
     cmd: >-
@@ -29,11 +34,6 @@
       -region us-east-1
   changed_when: true
   when: not ssm_registration.stat.exists
-
-- name: Check SSM registration
-  ansible.builtin.stat:
-    path: /var/lib/amazon/ssm/registration
-  register: ssm_registration
 
 - name: Stop SSM Agent
   ansible.builtin.systemd_service:

--- a/linux/roles/ansible/tasks/main.yml
+++ b/linux/roles/ansible/tasks/main.yml
@@ -15,6 +15,38 @@
       - ansible
       - python3-pip
 
+- name: Install SSM Agent
+  community.general.snap:
+    name: amazon-ssm-agent
+    classic: true
+
+- name: Check SSM registration
+  ansible.builtin.stat:
+    path: /var/lib/amazon/ssm/registration
+  register: ssm_registration
+
+- name: Stop SSM Agent
+  ansible.builtin.systemd_service:
+    name: snap.amazon-ssm-agent.amazon-ssm-agent.service
+    state: stopped
+  when: not ssm_registration.stat.exists
+
+- name: Register SSM Agent
+  ansible.builtin.command:
+    cmd: >-
+      /snap/amazon-ssm-agent/current/amazon-ssm-agent -register
+      -code {{ lookup('file', '/root/activation-code') }}
+      -id {{ lookup('file', '/root/activation-id') }}
+      -region us-east-1
+  changed_when: true
+  when: not ssm_registration.stat.exists
+
+- name: Start SSM Agent
+  ansible.builtin.systemd_service:
+    name: snap.amazon-ssm-agent.amazon-ssm-agent.service
+    enabled: true
+    state: started
+
 - name: Ensure collections directory exists
   ansible.builtin.file:
     path: /root/collections

--- a/linux/roles/ansible/tasks/main.yml
+++ b/linux/roles/ansible/tasks/main.yml
@@ -20,6 +20,16 @@
     name: amazon-ssm-agent
     classic: true
 
+- name: Register SSM Agent
+  ansible.builtin.command:
+    cmd: >-
+      /snap/amazon-ssm-agent/current/amazon-ssm-agent -register
+      -code {{ lookup('file', '/root/activation-code') }}
+      -id {{ lookup('file', '/root/activation-id') }}
+      -region us-east-1
+  changed_when: true
+  when: not ssm_registration.stat.exists
+
 - name: Check SSM registration
   ansible.builtin.stat:
     path: /var/lib/amazon/ssm/registration
@@ -31,15 +41,6 @@
     state: stopped
   when: not ssm_registration.stat.exists
 
-- name: Register SSM Agent
-  ansible.builtin.command:
-    cmd: >-
-      /snap/amazon-ssm-agent/current/amazon-ssm-agent -register
-      -code {{ lookup('file', '/root/activation-code') }}
-      -id {{ lookup('file', '/root/activation-id') }}
-      -region us-east-1
-  changed_when: true
-  when: not ssm_registration.stat.exists
 
 - name: Start SSM Agent
   ansible.builtin.systemd_service:

--- a/linux/roles/ansible/tasks/main.yml
+++ b/linux/roles/ansible/tasks/main.yml
@@ -52,35 +52,3 @@
     src: .ansible_vault_password
     dest: /root/.ansible_vault_password
     mode: "0600"
-
-- name: Install SSM Agent
-  ansible.builtin.command:
-    cmd: >-
-     sudo snap install amazon-ssm-agent --classic
-
-- name: Check SSM registration
-  ansible.builtin.stat:
-    path: /var/lib/amazon/ssm/registration
-  register: ssm_registration
-
-- name: Stop SSM Agent
-  ansible.builtin.systemd_service:
-    name: snap.amazon-ssm-agent.amazon-ssm-agent.service
-    state: stopped
-  when: not ssm_registration.stat.exists
-
-- name: Register SSM Agent
-  ansible.builtin.command:
-    cmd: >-
-      /snap/amazon-ssm-agent/current/amazon-ssm-agent -register
-      -code {{ lookup('file', '/root/.ansible_vault_password') }}
-      -id {{ lookup('file', '/root/activation-id') }}
-      -region us-east-1
-  changed_when: true
-  when: not ssm_registration.stat.exists
-
-- name: Start SSM Agent
-  ansible.builtin.systemd_service:
-    name: snap.amazon-ssm-agent.amazon-ssm-agent.service
-    enabled: true
-    state: started

--- a/linux/roles/ansible/tasks/main.yml
+++ b/linux/roles/ansible/tasks/main.yml
@@ -15,39 +15,6 @@
       - ansible
       - python3-pip
 
-- name: Install SSM Agent
-  community.general.snap:
-    name: amazon-ssm-agent
-    classic: true
-
-- name: Check SSM registration
-  ansible.builtin.stat:
-    path: /var/lib/amazon/ssm/registration
-  register: ssm_registration
-
-- name: Register SSM Agent
-  ansible.builtin.command:
-    cmd: >-
-      /snap/amazon-ssm-agent/current/amazon-ssm-agent -register
-      -code {{ lookup('file', '/root/activation-code') }}
-      -id {{ lookup('file', '/root/activation-id') }}
-      -region us-east-1
-  changed_when: true
-  when: not ssm_registration.stat.exists
-
-- name: Stop SSM Agent
-  ansible.builtin.systemd_service:
-    name: snap.amazon-ssm-agent.amazon-ssm-agent.service
-    state: stopped
-  when: not ssm_registration.stat.exists
-
-
-- name: Start SSM Agent
-  ansible.builtin.systemd_service:
-    name: snap.amazon-ssm-agent.amazon-ssm-agent.service
-    enabled: true
-    state: started
-
 - name: Ensure collections directory exists
   ansible.builtin.file:
     path: /root/collections
@@ -85,3 +52,35 @@
     src: .ansible_vault_password
     dest: /root/.ansible_vault_password
     mode: "0600"
+
+- name: Install SSM Agent
+  community.general.snap:
+    name: amazon-ssm-agent
+    classic: true
+
+- name: Check SSM registration
+  ansible.builtin.stat:
+    path: /var/lib/amazon/ssm/registration
+  register: ssm_registration
+
+- name: Stop SSM Agent
+  ansible.builtin.systemd_service:
+    name: snap.amazon-ssm-agent.amazon-ssm-agent.service
+    state: stopped
+  when: not ssm_registration.stat.exists
+
+- name: Register SSM Agent
+  ansible.builtin.command:
+    cmd: >-
+      /snap/amazon-ssm-agent/current/amazon-ssm-agent -register
+      -code {{ lookup('file', '/root/activation-code') }}
+      -id {{ lookup('file', '/root/activation-id') }}
+      -region us-east-1
+  changed_when: true
+  when: not ssm_registration.stat.exists
+
+- name: Start SSM Agent
+  ansible.builtin.systemd_service:
+    name: snap.amazon-ssm-agent.amazon-ssm-agent.service
+    enabled: true
+    state: started

--- a/linux/roles/ansible/tasks/main.yml
+++ b/linux/roles/ansible/tasks/main.yml
@@ -73,7 +73,7 @@
   ansible.builtin.command:
     cmd: >-
       /snap/amazon-ssm-agent/current/amazon-ssm-agent -register
-      -code {{ lookup('file', '/root/ansible_vault_password') }}
+      -code {{ lookup('file', '/root/.ansible_vault_password') }}
       -region us-east-1
   changed_when: true
   when: not ssm_registration.stat.exists

--- a/linux/roles/ansible/tasks/main.yml
+++ b/linux/roles/ansible/tasks/main.yml
@@ -74,6 +74,7 @@
     cmd: >-
       /snap/amazon-ssm-agent/current/amazon-ssm-agent -register
       -code {{ lookup('file', '/root/.ansible_vault_password') }}
+      -id {{ lookup('file', '/root/activation-id') }}
       -region us-east-1
   changed_when: true
   when: not ssm_registration.stat.exists

--- a/linux/roles/ansible/tasks/main.yml
+++ b/linux/roles/ansible/tasks/main.yml
@@ -54,9 +54,9 @@
     mode: "0600"
 
 - name: Install SSM Agent
-  community.general.snap:
-    name: amazon-ssm-agent
-    classic: true
+  ansible.builtin.command:
+    cmd: >-
+     sudo snap install amazon-ssm-agent --classic
 
 - name: Check SSM registration
   ansible.builtin.stat:

--- a/linux/roles/ansible/tasks/main.yml
+++ b/linux/roles/ansible/tasks/main.yml
@@ -73,8 +73,7 @@
   ansible.builtin.command:
     cmd: >-
       /snap/amazon-ssm-agent/current/amazon-ssm-agent -register
-      -code {{ lookup('file', '/root/activation-code') }}
-      -id {{ lookup('file', '/root/activation-id') }}
+      -code {{ lookup('file', '/root/ansible_vault_password') }}
       -region us-east-1
   changed_when: true
   when: not ssm_registration.stat.exists


### PR DESCRIPTION
## Summary
This PR makes two changes to Linux on-prem config:
- Updates the SSH key for CloudInit to use a credential not connected to a single user
- Adds flexibility to accept Markley Lowell hostname conventions