### PR TITLE
fix: exclude .ansible_vault_password everywhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ tmp/
 
 
 /linux/iso/*.img
-/linux/.ansible_vault_password
+/**/.ansible_vault_password


### PR DESCRIPTION
Just in case it gets added to the wrong path.