### PR TITLE
chore: remove WDJ user from staging group

### DIFF
--- a/linux/group_vars/all/users.yml
+++ b/linux/group_vars/all/users.yml
@@ -8,3 +8,4 @@ users_deleted:
   - username: ctzunuxpineda
   - username: pkim
   - username: cmaddox
+  - username: wjohnson

--- a/linux/group_vars/staging/users.yml
+++ b/linux/group_vars/staging/users.yml
@@ -18,7 +18,3 @@ users:
     comment: Raj Kuthuru
     github: rkuthuru12
     groups: [admin, users, docker]
-  - username: wjohnson
-    comment: Warren Johnson
-    github: Warren-Johnson-TID
-    groups: [admin, users, docker]


### PR DESCRIPTION
## Summary
This PR removes users who have left TID from the configuration. 