### PR TITLE
configure TESTSCU001 as a staging machine

### DIFF
--- a/linux/group_vars/scu/env.yml
+++ b/linux/group_vars/scu/env.yml
@@ -1,4 +1,5 @@
 ---
 
 scu_env: prod
+scu_deploy_tag: prod
 scu_autostart: true

--- a/linux/inventory.yml
+++ b/linux/inventory.yml
@@ -154,8 +154,11 @@ scu:
     SEAVSCU001:
     SWTCSCU001:
     TESTSCU[001:099]:
+      scu_deploy_tag: staging
     TESTSCU[100:899]:
       scu_env: staging
+      scu_deploy_tag: staging
     TESTSCU[900:999]:
       scu_env: staging
+      scu_deploy_tag: staging
       scu_autostart: false

--- a/linux/roles/scu/templates/docker-compose.yaml.j2
+++ b/linux/roles/scu/templates/docker-compose.yaml.j2
@@ -1,6 +1,6 @@
 services:
   scully:
-    image: {{ aws_account_id }}.dkr.ecr.{{ aws_region }}.amazonaws.com/scully:{{ scu_env }}
+    image: {{ aws_account_id }}.dkr.ecr.{{ aws_region }}.amazonaws.com/scully:{{ scu_deploy_tag }}
     devices:
       - "/dev/asihpi:/dev/asihpi"
     ports:

--- a/linux/roles/scu/templates/set-audio-mode.j2
+++ b/linux/roles/scu/templates/set-audio-mode.j2
@@ -7,5 +7,5 @@ docker run --rm \
     --privileged \
     --device=/dev/asihpi:/dev/asihpi \
     --env-file /root/scully.env \
-    {{ aws_account_id }}.dkr.ecr.{{ aws_region }}.amazonaws.com/scully:{{ scu_env }} \
+    {{ aws_account_id }}.dkr.ecr.{{ aws_region }}.amazonaws.com/scully:{{ scu_deploy_tag }} \
     /scully/bin/scully eval "AudioTasks.set_audio_mode()"


### PR DESCRIPTION
[Make TESTSCU001 part of "staging"](https://app.asana.com/1/15492006741476/project/1185117109217422/task/1211209953794209?focus=true)

This reconfigures TESTSCU001 as a staging deploy target, while otherwise keeping it as a "prod" environment. Splitting the config like this is necessary because we want to continue to have RTS prod send messages to it, which means it needs to use the prod API key.