### PR TITLE
chore: use bundled versions of builtin collections

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,6 @@ jobs:
       - name: Install yamllint
         run: ~/.asdf/installs/ansible/*/venv/bin/python3 -m pip install yamllint
       - uses: mbta/actions/reshim-asdf@v1
-      - name: Install Ansible Galaxy collections
-        run: ansible-galaxy collection install -r linux/collections/requirements.yml
       - name: Run ansible-lint
         run: ~/.asdf/installs/ansible/*/venv/bin/ansible-lint --format full
         working-directory: linux

--- a/linux/collections/requirements.yml
+++ b/linux/collections/requirements.yml
@@ -1,9 +1,0 @@
----
-
-collections:
-  - name: community.general
-    version: "6.6.1"
-  - name: amazon.aws
-    version: "6.1.0"
-  - name: ansible.posix
-    version: "1.5.4"

--- a/linux/roles/ansible/tasks/main.yml
+++ b/linux/roles/ansible/tasks/main.yml
@@ -14,29 +14,16 @@
       - ansible
       - python3-pip
 
-- name: Ensure collections directory exists
-  ansible.builtin.file:
-    path: /root/collections
-    state: directory
-    mode: "0700"
-
-- name: Copy requirements file
-  register: ansible_requirements
-  ansible.builtin.copy:
-    src: collections/requirements.yml
-    dest: /root/collections/requirements.yml
-    mode: "0600"
-
 # required by amazon.aws collection
 - name: Ensure boto3 package is installed
   ansible.builtin.pip:
     name: boto3
 
-- name: Install Ansible dependencies
-  community.general.ansible_galaxy_install:
-    type: collection
-    requirements_file: /root/collections/requirements.yml
-  when: ansible_requirements.changed  # noqa: no-handler
+# can be removed once run on all hosts
+- name: Remove non-builtin Ansible collections
+  ansible.builtin.file:
+    path: /root/.ansible/collections
+    state: absent
 
 - name: Check for local Ansible Vault password
   delegate_to: localhost


### PR DESCRIPTION
A requirements file was originally added to install newer versions of collections bundled with Ansible (see 3682a3b), but we are now using a newer version of Ansible and these versions are substantially *behind* the bundled ones.

We are currently installing Ansible 10.7.0 on managed Linux machines, per the [PPA](https://launchpad.net/~ansible/+archive/ubuntu/ansible). Collections bundled with this version are
[listed here](https://github.com/ansible-community/ansible-build-data/blob/main/10/ansible-10.7.0.deps).

This updates:

* `community.general` from 6.6.1 to 9.5.2 (see breaking changes for [7.0.0](https://github.com/ansible-collections/community.general/blob/stable-7/CHANGELOG.md#breaking-changes--porting-guide), [8.0.0](https://github.com/ansible-collections/community.general/blob/stable-8/CHANGELOG.md#breaking-changes--porting-guide), [9.0.0](https://github.com/ansible-collections/community.general/blob/stable-9/CHANGELOG.md#breaking-changes--porting-guide))
* `amazon.aws` from 6.1.0 to 8.2.1 (see breaking changes for [7.0.0](https://github.com/ansible-collections/amazon.aws/blob/stable-7/CHANGELOG.rst#breaking-changes-porting-guide), [8.0.0](https://github.com/ansible-collections/amazon.aws/blob/stable-8/CHANGELOG.rst#breaking-changes-porting-guide))
* `ansible.posix` from 1.5.4 to 1.6.2 (see [release notes](https://github.com/ansible-collections/ansible.posix/blob/main/CHANGELOG.rst#v162))

I reviewed the breaking changes and it doesn't appear that we're using any of the impacted features, but would definitely like a second opinion.