### PR TITLE
chore: remove PPCTDLNXPRD and STG from inventory

### DIFF
--- a/linux/inventory.yml
+++ b/linux/inventory.yml
@@ -19,7 +19,6 @@ staging:
       ecs_anywhere_attributes:
         com.mbta.ctd.primary-instance:
     HSCTDLNXSTG[02:99]:
-    PPCTDLNXSTG[01:99]:
 
 arrival_screen:
   hosts:
@@ -31,7 +30,6 @@ prod:
       ecs_anywhere_attributes:
         com.mbta.ctd.primary-instance:
     HSCTDLNXPRD[02:99]:
-    PPCTDLNXPRD[01:99]:
     MLLTIDAPP[01:99]P:
 
 splunk_base_image:


### PR DESCRIPTION
## Summary
This PR removes the PPCTDLNXPRD server from our inventory. It does the same for never-used PPCTDLNXSTG, as all Park Plaza datacenters have migrated (or will soon migrate) to Markley Lowell. 

I didn't touch the Splunk items in inventory because I wasn't sure of the InfoSec plan for migrating/decommissioning these servers. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210811468864162