### PR TITLE
add SCU audio cache and Watts env

### DIFF
--- a/linux/roles/scu/templates/create-scully-env.j2
+++ b/linux/roles/scu/templates/create-scully-env.j2
@@ -13,6 +13,8 @@ read_secret() {
 cat << EOF > /root/scully.env
 SCULLY_STATION_ID=$(hostname)
 SCULLY_API_KEY=$(read_secret scully-{{ scu_env }}-api-key)
+WATTS_URL=https://watts{{ "-staging" if scu_env == "staging" }}.mbtace.com
+WATTS_API_KEY=$(read_secret watts-{{ scu_env }}-api-key)
 SCULLY_SPLUNK_INDEX=scully-{{ scu_env }}
 SPLUNK_TOKEN=$(read_secret lambda-generic-splunk-token)
 SECRET_KEY_BASE=$(read_secret scully-{{ scu_env }}-secret-key-base)

--- a/linux/roles/scu/templates/docker-compose.yaml.j2
+++ b/linux/roles/scu/templates/docker-compose.yaml.j2
@@ -1,9 +1,13 @@
 services:
   scully:
     image: {{ aws_account_id }}.dkr.ecr.{{ aws_region }}.amazonaws.com/scully:{{ scu_deploy_tag }}
+    volumes:
+      - audio-cache:/audio_cache
     devices:
       - "/dev/asihpi:/dev/asihpi"
     ports:
       - "80:4010"
     env_file: scully.env
     restart: always
+volumes:
+  audio-cache:


### PR DESCRIPTION
This adds a volume to the compose file for Scully, which will be used for the new audio cache. Also injects the Watts URL and key into the environment, so it will be able to make calls.