### PR TITLE
reconfigure TESTSCU001 as staging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ jobs:
           key: ${{ runner.os }}-asdf-${{ hashFiles('.tool-versions') }}
         id: asdf-cache
       # only run `asdf install` if we didn't hit the cache
-      - uses: asdf-vm/actions/setup@v2
+      - uses: asdf-vm/actions/setup@v4
         if: steps.asdf-cache.outputs.cache-hit != 'true'
-      - uses: asdf-vm/actions/install@v2
+      - uses: asdf-vm/actions/install@v4
         if: steps.asdf-cache.outputs.cache-hit != 'true'
 
   lint_scripts:

--- a/linux/inventory.yml
+++ b/linux/inventory.yml
@@ -151,9 +151,7 @@ scu:
     SDUDSCU001:
     SEAVSCU001:
     SWTCSCU001:
-    TESTSCU[001:099]:
-      scu_deploy_tag: staging
-    TESTSCU[100:899]:
+    TESTSCU[001:899]:
       scu_env: staging
       scu_deploy_tag: staging
     TESTSCU[900:999]:


### PR DESCRIPTION
This changes TESTSCU001 to act as a normal staging environment, instead of a "prod" environment running staging code. Note that this will temporarily break the server, since there will be a mismatch between the credentials and what it's trying to read, but that's okay because we plan to reinstall it shortly.