### PR TITLE
Chore: add zizmor to workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,15 @@ name: CI
 
 on:
   push:
+    branches-ignore:
+      - main
 
 permissions:
-  contents: read
+  contents: read # private repo, needs permission to read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   zizmor:
@@ -19,6 +25,7 @@ jobs:
       - name: Run zizmor 🌈
         uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
         with:
+          persona: pedantic
           advanced-security: false
           annotations: true
   setup:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,28 +1,45 @@
 ---
-
 name: CI
 
 on:
   push:
-  pull_request:
+
+permissions:
+  contents: read
 
 jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          advanced-security: false
+          annotations: true
   setup:
     name: Setup
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       # cache the ASDF directory, using the values from .tool-versions
       - name: ASDF cache
-        uses: actions/cache@v3
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ~/.asdf
           key: ${{ runner.os }}-asdf-${{ hashFiles('.tool-versions') }}
         id: asdf-cache
       # only run `asdf install` if we didn't hit the cache
-      - uses: asdf-vm/actions/setup@v4
+      - uses: asdf-vm/actions/setup@b7bcd026f18772e44fe1026d729e1611cc435d47 # v4.0.1
         if: steps.asdf-cache.outputs.cache-hit != 'true'
-      - uses: asdf-vm/actions/install@v4
+      - uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47 # v4.0.1
         if: steps.asdf-cache.outputs.cache-hit != 'true'
 
   lint_scripts:
@@ -30,13 +47,16 @@ jobs:
     runs-on: ubuntu-22.04
     needs: setup
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: ASDF cache
-        uses: actions/cache@v3
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ~/.asdf
           key: ${{ runner.os }}-asdf-${{ hashFiles('.tool-versions') }}
-      - uses: mbta/actions/reshim-asdf@v1
+      - uses: mbta/actions/reshim-asdf@d37877022d4ae12e96663d2e0a970a5214a2e232 # v2.20
       - name: Shellcheck
         run: shellcheck **/*.sh
 
@@ -45,18 +65,21 @@ jobs:
     runs-on: ubuntu-22.04
     needs: setup
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: ASDF cache
-        uses: actions/cache@v3
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ~/.asdf
           key: ${{ runner.os }}-asdf-${{ hashFiles('.tool-versions') }}
       - name: Python venv cache
-        uses: actions/cache@v3
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: .venv
           key: ${{ runner.os }}-venv-${{ hashFiles('uv.lock') }}
-      - uses: mbta/actions/reshim-asdf@v1
+      - uses: mbta/actions/reshim-asdf@d37877022d4ae12e96663d2e0a970a5214a2e232 # v2.20
       - name: Run ansible-lint
         run: uv run ansible-lint --format full
         working-directory: linux

--- a/.github/workflows/vagrant-up.yml
+++ b/.github/workflows/vagrant-up.yml
@@ -11,10 +11,15 @@ on:
   #     - linux/**
 
 permissions:
-  contents: read
+  contents: read # private repo, needs permission to read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   vagrant-up:
+    name: Run Vagrant Up
     runs-on: macos-latest
     env:
       VAGRANT_HOSTNAME: github

--- a/.github/workflows/vagrant-up.yml
+++ b/.github/workflows/vagrant-up.yml
@@ -10,6 +10,9 @@ on:
   #   paths:
   #     - linux/**
 
+permissions:
+  contents: read
+
 jobs:
   vagrant-up:
     runs-on: macos-latest
@@ -18,9 +21,12 @@ jobs:
       GITHUB_REPO: ${{ github.repository }}
       GIT_BRANCH: ${{ github.ref_name }}
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Cache Vagrant boxes
-        uses: actions/cache@v3
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ~/.vagrant.d
           key: ${{ runner.os }}-vagrant-${{ hashFiles('linux/Vagrantfile') }}


### PR DESCRIPTION
Add Zizmor to the Checks GH Workflow

Output of manual Zizmor:
```
% zizmor .
 INFO zizmor: 🌈 zizmor v1.26.1
 INFO audit: zizmor: 🌈 completed ./.github/workflows/ci.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/vagrant-up.yml
No findings to report. Good job! (4 suppressed)
```